### PR TITLE
Added nkey authentication support

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -53,6 +53,7 @@ type NATSConfiguration struct {
 	SubjectPrefix    string   `toml:"subject_prefix"`
 	StreamPrefix     string   `toml:"stream_prefix"`
 	ServerConfigFile string   `toml:"server_config"`
+	SeedFile         string   `toml:"seed_file"`
 }
 
 type LoggingConfiguration struct {

--- a/config.toml
+++ b/config.toml
@@ -105,6 +105,12 @@ subject_prefix="marmot-change-log"
 # JetStream name prefix used for publishing log entries, it's usually suffixed by shard number
 # to get the full JetStream name
 stream_prefix="marmot-changes"
+# Seed file used for client nkey authentication
+# nk -gen user > user.seed
+# nk -inkey user.seed -pubout > user.pub
+# Set to user.seed
+# Reference https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt#what-are-nkeys
+seed_file=""
 
 
 # Console STDOUT configurations

--- a/stream/nats.go
+++ b/stream/nats.go
@@ -1,10 +1,11 @@
 package stream
 
 import (
-	"github.com/maxpert/marmot/cfg"
-	"github.com/nats-io/nats.go"
 	"strings"
 	"time"
+
+	"github.com/maxpert/marmot/cfg"
+	"github.com/nats-io/nats.go"
 )
 
 func Connect() (*nats.Conn, error) {
@@ -21,6 +22,15 @@ func Connect() (*nats.Conn, error) {
 		}
 
 		opts = append(opts, nats.InProcessServer(server))
+	}
+
+	if cfg.Config.NATS.SeedFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(cfg.Config.NATS.SeedFile)
+		if err != nil {
+			return nil, err
+		}
+
+		opts = append(opts, opt)
 	}
 
 	nc, err := nats.Connect(serverUrl, opts...)


### PR DESCRIPTION
```bash
nk -gen user > user.seed
nk -inkey user.seed -pubout > user.pub
```
Then copy user.pub's content into `nats-server.conf` :
```bash
accounts: {
  client: {  # user/account name
    jetstream: enable
    users: [
       { nkey: UDPXDY67FKWMCXHDQ5HGYODLFTBWJIHHUDMIAJWPDICIS5UMMLM5KGDZ }
    ]
  }
}
```
The file `user.seed` is specified in `config.toml` under `seed_file`.