### PR TITLE
Periodic snapshot support

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -46,6 +46,7 @@ type ObjectStoreConfiguration struct {
 
 type SnapshotConfiguration struct {
 	Enable    bool                     `toml:"enabled"`
+	Interval  uint32                   `toml:"interval"`
 	StoreType SnapshotStoreType        `toml:"store"`
 	Nats      ObjectStoreConfiguration `toml:"nats"`
 	S3        S3Configuration          `toml:"s3"`
@@ -104,6 +105,7 @@ var Config = &Configuration{
 
 	Snapshot: SnapshotConfiguration{
 		Enable:    true,
+		Interval:  0,
 		StoreType: Nats,
 		Nats: ObjectStoreConfiguration{
 			Replicas: 1,

--- a/config.toml
+++ b/config.toml
@@ -46,8 +46,8 @@ enabled=true
 # Storage for snapshot can be "nats" | "s3" (default "nats")
 store="nats"
 # Interval sets perodic interval in milliseconds after which an automatic snapshot should be saved
-# If there has been a snapshot within interval range due to other log threshold, then that
-# snapshot will be respected, a value of 0 means it's disabled
+# If there was a snapshot saved within interval range due to other log threshold triggers, then
+# new snapshot won't be saved (since it's within time range), a value of 0 means it's disabled.
 interval=0
 
 # When setting snapshot.store to "nats" [snapshot.nats] will be used to configure snapshotting details

--- a/config.toml
+++ b/config.toml
@@ -45,6 +45,10 @@ db_path="/tmp/marmot.db"
 enabled=true
 # Storage for snapshot can be "nats" | "s3" (default "nats")
 store="nats"
+# Interval sets perodic interval in milliseconds after which an automatic snapshot should be saved
+# If there has been a snapshot within interval range due to other log threshold, then that
+# snapshot will be respected, a value of 0 means it's disabled
+interval=0
 
 # When setting snapshot.store to "nats" [snapshot.nats] will be used to configure snapshotting details
 # NATS connection settings (urls etc.) will be loaded from global [nats] configurations

--- a/db/change_log.go
+++ b/db/change_log.go
@@ -268,6 +268,8 @@ func (conn *SqliteStreamDB) watchChanges(watcher *fsnotify.Watcher, path string)
 	conn.publishChangeLog()
 
 	for {
+		changeLogTicker.Reset()
+
 		err := conn.WithReadTx(func(_tx *sql.Tx) error {
 			select {
 			case ev, ok := <-watcher.Events:
@@ -303,8 +305,6 @@ func (conn *SqliteStreamDB) watchChanges(watcher *fsnotify.Watcher, path string)
 		if errWal != nil {
 			errWal = watcher.Add(walPath)
 		}
-
-		changeLogTicker.Reset()
 	}
 }
 

--- a/logstream/replicator.go
+++ b/logstream/replicator.go
@@ -89,7 +89,7 @@ func NewReplicator(
 		client:             nc,
 		nodeID:             nodeID,
 		compressionEnabled: compress,
-		lastSnapshot:       time.Now(),
+		lastSnapshot:       time.Time{},
 
 		shards:    shards,
 		streamMap: streamMap,

--- a/logstream/replicator.go
+++ b/logstream/replicator.go
@@ -21,6 +21,7 @@ type Replicator struct {
 	nodeID             uint64
 	shards             uint64
 	compressionEnabled bool
+	lastSnapshot       time.Time
 
 	client    *nats.Conn
 	repState  *replicationState
@@ -88,6 +89,7 @@ func NewReplicator(
 		client:             nc,
 		nodeID:             nodeID,
 		compressionEnabled: compress,
+		lastSnapshot:       time.Now(),
 
 		shards:    shards,
 		streamMap: streamMap,
@@ -214,6 +216,10 @@ func (r *Replicator) RestoreSnapshot() error {
 	return nil
 }
 
+func (r *Replicator) LastSaveSnapshotTime() time.Time {
+	return r.lastSnapshot
+}
+
 func (r *Replicator) SaveSnapshot() {
 	if r.snapshot == nil {
 		return
@@ -224,7 +230,10 @@ func (r *Replicator) SaveSnapshot() {
 		log.Error().
 			Err(err).
 			Msg("Unable snapshot database")
+		return
 	}
+
+	r.lastSnapshot = time.Now()
 }
 
 func (r *Replicator) invokeListener(callback func(payload []byte) error, msg *nats.Msg) error {

--- a/utils/timeout.go
+++ b/utils/timeout.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
+	"time"
+
 	"github.com/asaskevich/EventBus"
 	"github.com/rs/zerolog/log"
-	"time"
 )
 
 type TimeoutPublisher struct {
@@ -35,7 +36,6 @@ func NewTimeoutPublisher(duration time.Duration) *TimeoutPublisher {
 	}
 
 	ticker := time.NewTicker(duration)
-	ticker.Stop()
 	return &TimeoutPublisher{duration: duration, ticker: ticker, publisher: nil}
 }
 


### PR DESCRIPTION
This PR will enable saving snapshots periodically. While high amount of changes with a large log size can cause snapshot saving to be triggered, this will allow low write traffic scenarios to save whatever small changes they have with periodic snapshots. 