### PR TITLE
Updating stream config at boot time if settings not match up

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -23,10 +23,11 @@ const (
 )
 
 type ReplicationLogConfiguration struct {
-	Shards     uint64 `toml:"shards"`
-	MaxEntries int64  `toml:"max_entries"`
-	Replicas   int    `toml:"replicas"`
-	Compress   bool   `toml:"compress"`
+	Shards         uint64 `toml:"shards"`
+	MaxEntries     int64  `toml:"max_entries"`
+	Replicas       int    `toml:"replicas"`
+	Compress       bool   `toml:"compress"`
+	UpdateExisting bool   `toml:"update_existing"`
 }
 
 type S3Configuration struct {
@@ -114,10 +115,11 @@ var Config = &Configuration{
 	},
 
 	ReplicationLog: ReplicationLogConfiguration{
-		Shards:     1,
-		MaxEntries: 1024,
-		Replicas:   1,
-		Compress:   true,
+		Shards:         1,
+		MaxEntries:     1024,
+		Replicas:       1,
+		Compress:       true,
+		UpdateExisting: false,
 	},
 
 	NATS: NATSConfiguration{

--- a/config.toml
+++ b/config.toml
@@ -94,6 +94,10 @@ max_entries=1024
 # Enable log compression, uses zstd to compress logs as they are streamd to NATS
 # This is useful for DB storing large blobs that can be compressed.
 compress=true
+# Update existing stream if the configurations of JetStream don't match up with configurations
+# generated due to parameters above. Use this option carefully because changing shards,
+# or max_etries etc. might have undesired side-effects on existing running cluster
+update_existing=false
 
 
 # NATS server configurations

--- a/logstream/replicator.go
+++ b/logstream/replicator.go
@@ -30,11 +30,13 @@ type Replicator struct {
 }
 
 func NewReplicator(
-	nodeID uint64,
-	shards uint64,
-	compress bool,
 	snapshot snapshot.NatsSnapshot,
 ) (*Replicator, error) {
+	nodeID := cfg.Config.NodeID
+	shards := cfg.Config.ReplicationLog.Shards
+	compress := cfg.Config.ReplicationLog.Compress
+	updateExisting := cfg.Config.ReplicationLog.UpdateExisting
+
 	nc, err := stream.Connect()
 	if err != nil {
 		return nil, err
@@ -63,7 +65,7 @@ func NewReplicator(
 			return nil, err
 		}
 
-		if !eqShardStreamConfig(&info.Config, streamCfg) {
+		if updateExisting && !eqShardStreamConfig(&info.Config, streamCfg) {
 			log.Warn().Msgf("Stream configuration not same for %s, updating...", streamName(shard, compress))
 			info, err = js.UpdateStream(streamCfg)
 			if err != nil {

--- a/marmot.go
+++ b/marmot.go
@@ -66,12 +66,7 @@ func main() {
 		log.Panic().Err(err).Msg("Unable to initialize snapshot storage")
 	}
 
-	replicator, err := logstream.NewReplicator(
-		cfg.Config.NodeID,
-		cfg.Config.ReplicationLog.Shards,
-		cfg.Config.ReplicationLog.Compress,
-		snapshot.NewNatsDBSnapshot(streamDB, snpStore),
-	)
+	replicator, err := logstream.NewReplicator(snapshot.NewNatsDBSnapshot(streamDB, snpStore))
 	if err != nil {
 		log.Panic().Err(err).Msg("Unable to initialize replicators")
 	}


### PR DESCRIPTION
Previously Marmot won't readjust the settings for a stream if it was already created, while this worked fine for external NATS servers, it might be desirable to have a mechanism to update those streams from within Marmot at boot time. 