### PR TITLE
Optimizing NATS snapshotting for low memory environments

### DIFF
--- a/stream/embedded_nats.go
+++ b/stream/embedded_nats.go
@@ -51,7 +51,7 @@ func startEmbeddedServer(nodeName string) (*embeddedNats, error) {
 		Port:               -1,
 		NoSigs:             true,
 		JetStream:          true,
-		JetStreamMaxMemory: 1 << 25,
+		JetStreamMaxMemory: 1 << 20,
 		JetStreamMaxStore:  1 << 30,
 		Cluster: server.ClusterOpts{
 			Name: "e-marmot",


### PR DESCRIPTION
It's a trial change to check if having a retry logic for large snapshots and low JS memory limits actually helps. 