### PR TITLE
Fixing datetime replication

### DIFF
--- a/core/events.go
+++ b/core/events.go
@@ -1,0 +1,10 @@
+package core
+
+import "github.com/fxamacker/cbor/v2"
+
+var CBORTags = cbor.NewTagSet()
+
+type ReplicableEvent[T any] interface {
+	Wrap() (T, error)
+	Unwrap() (T, error)
+}

--- a/db/change_log.go
+++ b/db/change_log.go
@@ -368,7 +368,7 @@ func (conn *SqliteStreamDB) publishChangeLog() {
 
 		err = conn.consumeChangeLogs(change.TableName, []*changeLogEntry{&logEntry})
 		if err != nil {
-			if err == ErrLogNotReadyToPublish || err == context.Canceled {
+			if errors.Is(err, ErrLogNotReadyToPublish) || errors.Is(err, context.Canceled) {
 				break
 			}
 

--- a/logstream/replication_event.go
+++ b/logstream/replication_event.go
@@ -1,16 +1,49 @@
 package logstream
 
-import "github.com/fxamacker/cbor/v2"
+import (
+	"github.com/fxamacker/cbor/v2"
+	"github.com/maxpert/marmot/core"
+)
 
-type ReplicationEvent[T any] struct {
+type ReplicationEvent[T core.ReplicableEvent[T]] struct {
 	FromNodeId uint64
-	Payload    *T
+	Payload    T
 }
 
 func (e *ReplicationEvent[T]) Marshal() ([]byte, error) {
-	return cbor.Marshal(e)
+	wrappedPayload, err := e.Payload.Wrap()
+	if err != nil {
+		return nil, err
+	}
+
+	ev := ReplicationEvent[T]{
+		FromNodeId: e.FromNodeId,
+		Payload:    wrappedPayload,
+	}
+
+	em, err := cbor.EncOptions{}.EncModeWithTags(core.CBORTags)
+	if err != nil {
+		return nil, err
+	}
+
+	return em.Marshal(ev)
 }
 
 func (e *ReplicationEvent[T]) Unmarshal(data []byte) error {
-	return cbor.Unmarshal(data, e)
+	dm, err := cbor.DecOptions{}.DecModeWithTags(core.CBORTags)
+	if err != nil {
+		return nil
+	}
+
+	err = dm.Unmarshal(data, e)
+	if err != nil {
+		return err
+	}
+
+	e.Payload, err = e.Payload.Unwrap()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/logstream/replicator.go
+++ b/logstream/replicator.go
@@ -2,6 +2,7 @@ package logstream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -178,8 +179,7 @@ func (r *Replicator) Listen(shardID uint64, callback func(payload []byte) error)
 	savedSeq := r.repState.get(streamName(shardID, r.compressionEnabled))
 	for sub.IsValid() {
 		msg, err := sub.NextMsg(5 * time.Second)
-
-		if err == nats.ErrTimeout {
+		if errors.Is(err, nats.ErrTimeout) {
 			continue
 		}
 
@@ -199,7 +199,7 @@ func (r *Replicator) Listen(shardID uint64, callback func(payload []byte) error)
 		err = r.invokeListener(callback, msg)
 		if err != nil {
 			msg.Nak()
-			if err == context.Canceled {
+			if errors.Is(err, context.Canceled) {
 				return nil
 			}
 

--- a/marmot.go
+++ b/marmot.go
@@ -189,7 +189,7 @@ func onChangeEvent(streamDB *db.SqliteStreamDB, ctxSt *utils.StateContext, event
 			return err
 		}
 
-		return streamDB.Replicate(ev.Payload)
+		return streamDB.Replicate(&ev.Payload)
 	}
 }
 
@@ -206,7 +206,7 @@ func onTableChanged(r *logstream.Replicator, ctxSt *utils.StateContext, events E
 
 		ev := &logstream.ReplicationEvent[db.ChangeLogEvent]{
 			FromNodeId: nodeID,
-			Payload:    event,
+			Payload:    *event,
 		}
 
 		data, err := ev.Marshal()


### PR DESCRIPTION
Turns out CBOR by default serializes date time into unix timestamp and drops the serialization information about it. This PR adds new struct and enforces tag to be serialized and deserialized along with the values.

This will fix issue #76 