### PR TITLE
Adding pprof flag to support better tracing & rewriting file watching

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -118,6 +118,7 @@ var SaveSnapshotFlag = flag.Bool("save-snapshot", false, "Only take snapshot and
 var ClusterAddrFlag = flag.String("cluster-addr", "", "Cluster listening address")
 var ClusterPeersFlag = flag.String("cluster-peers", "", "Comma separated list of clusters")
 var LeafServerFlag = flag.String("leaf-servers", "", "Comma separated list of leaf servers")
+var ProfServer = flag.String("pprof", "", "PProf listening address")
 
 var DataRootDir = os.TempDir()
 var Config = &Configuration{

--- a/db/change_log.go
+++ b/db/change_log.go
@@ -278,9 +278,11 @@ func (conn *SqliteStreamDB) watchChanges(watcher *fsnotify.Watcher, path string)
 				}
 
 				if ev.Op != fsnotify.Chmod {
+					log.Debug().Int("change", int(ev.Op)).Msg("Change detected")
 					conn.publishChangeLog()
 				}
 			case <-changeLogTicker.Channel():
+				log.Debug().Dur("timeout", tickerDur).Msg("Change polling timeout")
 				conn.publishChangeLog()
 			}
 

--- a/db/change_log.go
+++ b/db/change_log.go
@@ -263,6 +263,7 @@ func (conn *SqliteStreamDB) filterChangesTo(changed chan fsnotify.Event, watcher
 			}
 
 			if ev.Op == fsnotify.Chmod {
+				time.Sleep(1 * time.Millisecond)
 				continue
 			}
 
@@ -285,7 +286,7 @@ func (conn *SqliteStreamDB) watchChanges(watcher *fsnotify.Watcher, path string)
 
 	// Publish change logs for any residual change logs before starting watcher
 	conn.publishChangeLog()
-	conn.filterChangesTo(dbChanged, watcher)
+	go conn.filterChangesTo(dbChanged, watcher)
 
 	for {
 		changeLogTicker.Reset()

--- a/db/change_log.go
+++ b/db/change_log.go
@@ -263,7 +263,6 @@ func (conn *SqliteStreamDB) filterChangesTo(changed chan fsnotify.Event, watcher
 			}
 
 			if ev.Op == fsnotify.Chmod {
-				time.Sleep(1 * time.Millisecond)
 				continue
 			}
 

--- a/db/change_log.go
+++ b/db/change_log.go
@@ -253,6 +253,24 @@ func (conn *SqliteStreamDB) initTriggers(tableName string) error {
 	return nil
 }
 
+func (conn *SqliteStreamDB) filterChangesTo(changed chan fsnotify.Event, watcher *fsnotify.Watcher) {
+	for {
+		select {
+		case ev, ok := <-watcher.Events:
+			if !ok {
+				close(changed)
+				return
+			}
+
+			if ev.Op == fsnotify.Chmod {
+				continue
+			}
+
+			changed <- ev
+		}
+	}
+}
+
 func (conn *SqliteStreamDB) watchChanges(watcher *fsnotify.Watcher, path string) {
 	shmPath := path + "-shm"
 	walPath := path + "-wal"
@@ -260,33 +278,30 @@ func (conn *SqliteStreamDB) watchChanges(watcher *fsnotify.Watcher, path string)
 	errDB := watcher.Add(path)
 	errShm := watcher.Add(shmPath)
 	errWal := watcher.Add(walPath)
+	dbChanged := make(chan fsnotify.Event)
 
 	tickerDur := time.Duration(cfg.Config.PollingInterval) * time.Millisecond
 	changeLogTicker := utils.NewTimeoutPublisher(tickerDur)
 
 	// Publish change logs for any residual change logs before starting watcher
 	conn.publishChangeLog()
+	conn.filterChangesTo(dbChanged, watcher)
 
 	for {
 		changeLogTicker.Reset()
 
-		changesPublished := false
 		err := conn.WithReadTx(func(_tx *sql.Tx) error {
 			select {
-			case ev, ok := <-watcher.Events:
+			case ev, ok := <-dbChanged:
 				if !ok {
 					return ErrEndOfWatch
 				}
 
 				log.Debug().Int("change", int(ev.Op)).Msg("Change detected")
-				if ev.Op != fsnotify.Chmod {
-					conn.publishChangeLog()
-					changesPublished = true
-				}
+				conn.publishChangeLog()
 			case <-changeLogTicker.Channel():
 				log.Debug().Dur("timeout", tickerDur).Msg("Change polling timeout")
 				conn.publishChangeLog()
-				changesPublished = true
 			}
 
 			return nil
@@ -310,8 +325,6 @@ func (conn *SqliteStreamDB) watchChanges(watcher *fsnotify.Watcher, path string)
 		if errWal != nil {
 			errWal = watcher.Add(walPath)
 		}
-
-		log.Debug().Bool("changes", changesPublished).Msg("Changes published")
 	}
 }
 


### PR DESCRIPTION
Turns out people were noticing high CPU usage due to fsnotify flooding Marmot with `fsnotify.Chmod`. This PR introduces pprof flag to run marmot with profiling and fixes the issue. 