### PR TITLE
Ignore virtual tables when building the table list

### DIFF
--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -390,6 +390,7 @@ func copyFile(toPath, fromPath string) error {
 func listDBTables(names *[]string, gSQL *goqu.TxDatabase) error {
 	err := gSQL.Select("name").From("sqlite_schema").Where(
 		goqu.C("type").Eq("table"),
+                goqu.C("sql").NotLike("CREATE VIRTUAL TABLE%"),
 		goqu.C("name").NotLike("sqlite_%"),
 		goqu.C("name").NotLike(MarmotPrefix+"%"),
 	).ScanVals(names)


### PR DESCRIPTION
This PR causes marmot to ignore virtual tables when building the table list. It addresses the issue in #124.

Thanks!