### PR TITLE
Fix quorum ack failures and database connection stability

### DIFF
--- a/coordinator/conflict_resolver.go
+++ b/coordinator/conflict_resolver.go
@@ -126,10 +126,7 @@ func getConflictWindow() int64 {
 	return 10 * 1000 * 1000 * 1000 // Default: 10 seconds
 }
 
-// ConflictWindow is the default conflict window (deprecated - use getConflictWindow())
-const ConflictWindow = 10 * 1000 * 1000 * 1000 // 10 seconds
-
-// DefaultConflictHandler implements ConflictHandler with simple abort strategy
+// DefaultConflictHandler handles write-write conflicts by aborting the transaction
 type DefaultConflictHandler struct{}
 
 // OnConflict handles write-write conflicts by returning the error (aborting)

--- a/coordinator/conflict_resolver_test.go
+++ b/coordinator/conflict_resolver_test.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/maxpert/marmot/hlc"
@@ -347,5 +348,18 @@ func BenchmarkSelectWinner(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		cr.SelectWinner(timestamps)
+	}
+}
+
+// Tests for WaitingConflictHandler
+
+func TestDefaultConflictHandler_AlwaysReturnsError(t *testing.T) {
+	handler := &DefaultConflictHandler{}
+	txn := &Transaction{ID: 1}
+	testErr := fmt.Errorf("test conflict error")
+
+	result := handler.OnConflict(txn, testErr)
+	if result != testErr {
+		t.Errorf("DefaultConflictHandler should return the same error, got %v", result)
 	}
 }

--- a/coordinator/full_replication_test.go
+++ b/coordinator/full_replication_test.go
@@ -51,6 +51,7 @@ func TestFullReplication_QuorumWrite(t *testing.T) {
 	nodes := []uint64{1, 2, 3, 4, 5}
 	nodeProvider := newMockNodeProvider(nodes)
 	replicator := newMockReplicator()
+	clock := hlc.NewClock(1)
 
 	coordinator := NewWriteCoordinator(
 		1, // node 1 is coordinator
@@ -58,6 +59,7 @@ func TestFullReplication_QuorumWrite(t *testing.T) {
 		replicator,
 		replicator,
 		1*time.Second,
+		clock,
 	)
 
 	// Create a test transaction
@@ -104,6 +106,7 @@ func TestFullReplication_QuorumFailure(t *testing.T) {
 	nodes := []uint64{1, 2, 3, 4, 5}
 	nodeProvider := newMockNodeProvider(nodes)
 	replicator := newMockReplicator()
+	clock := hlc.NewClock(1)
 
 	// Make nodes 2, 3, 4 fail (only node 5 responds)
 	// With coordinator (1) + node 5 = 2 nodes, need 3 for quorum
@@ -117,6 +120,7 @@ func TestFullReplication_QuorumFailure(t *testing.T) {
 		replicator,
 		replicator,
 		1*time.Second,
+		clock,
 	)
 
 	txn := &Transaction{
@@ -152,6 +156,7 @@ func TestFullReplication_AllNodesReceiveWrite(t *testing.T) {
 	nodes := []uint64{1, 2, 3}
 	nodeProvider := newMockNodeProvider(nodes)
 	replicator := newMockReplicator()
+	clock := hlc.NewClock(1)
 
 	coordinator := NewWriteCoordinator(
 		1,
@@ -159,6 +164,7 @@ func TestFullReplication_AllNodesReceiveWrite(t *testing.T) {
 		replicator,
 		replicator,
 		1*time.Second,
+		clock,
 	)
 
 	txn := &Transaction{
@@ -202,6 +208,7 @@ func TestFullReplication_NodeFailureDuringWrite(t *testing.T) {
 	nodes := []uint64{1, 2, 3, 4, 5}
 	nodeProvider := newMockNodeProvider(nodes)
 	replicator := newMockReplicator()
+	clock := hlc.NewClock(1)
 
 	// Node 5 is dead/unresponsive
 	replicator.SetNodeResponse(5, &ReplicationResponse{Success: false})
@@ -212,6 +219,7 @@ func TestFullReplication_NodeFailureDuringWrite(t *testing.T) {
 		replicator,
 		replicator,
 		1*time.Second,
+		clock,
 	)
 
 	txn := &Transaction{

--- a/db/mvcc_integration_test.go
+++ b/db/mvcc_integration_test.go
@@ -420,19 +420,19 @@ func TestTransactionAbort(t *testing.T) {
 
 	t.Logf("✓ Write intents cleaned up after abort")
 
-	// Verify transaction record shows ABORTED
-	var status string
-	err = db.QueryRow("SELECT status FROM __marmot__txn_records WHERE txn_id = ?", txn.ID).
-		Scan(&status)
+	// Verify transaction record is deleted (aborted transactions are fully cleaned up)
+	var txnCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM __marmot__txn_records WHERE txn_id = ?", txn.ID).
+		Scan(&txnCount)
 	if err != nil {
-		t.Fatalf("Failed to read transaction record: %v", err)
+		t.Fatalf("Failed to query transaction record: %v", err)
 	}
 
-	if status != TxnStatusAborted {
-		t.Errorf("Transaction record status = %s, want ABORTED", status)
+	if txnCount != 0 {
+		t.Errorf("Transaction record not deleted: found %d records after abort", txnCount)
 	}
 
-	t.Logf("✓ Transaction record shows ABORTED status")
+	t.Logf("✓ Transaction record deleted after abort")
 }
 
 // TestExternalSQLiteReadability tests that external tools can read the DB

--- a/examples/join-cluster.sh
+++ b/examples/join-cluster.sh
@@ -39,11 +39,14 @@ echo "Data Dir:    ${DATA_DIR}"
 echo "Config:      ${CONFIG_FILE}"
 echo ""
 
-# Clean up previous data (optional - comment out to preserve data)
-if [ -d "${DATA_DIR}" ]; then
-    echo "Cleaning up previous data directory..."
-    rm -rf "${DATA_DIR}"
-fi
+# Kill any existing processes on our ports
+echo "Stopping any existing processes on ports ${MYSQL_PORT}, ${GRPC_PORT}..."
+lsof -ti:${MYSQL_PORT} -ti:${GRPC_PORT} 2>/dev/null | xargs kill 2>/dev/null || true
+sleep 1
+
+# Clean up previous data
+echo "Cleaning up previous data directory..."
+rm -rf "${DATA_DIR}"
 
 mkdir -p "${DATA_DIR}"
 
@@ -104,21 +107,18 @@ cat "${CONFIG_FILE}"
 echo "---"
 echo ""
 
-# Find marmot binary
-MARMOT_BIN=""
-if [ -f "./marmot-v2" ]; then
-    MARMOT_BIN="./marmot-v2"
-elif [ -f "./marmot" ]; then
-    MARMOT_BIN="./marmot"
-elif [ -f "../marmot-v2" ]; then
-    MARMOT_BIN="../marmot-v2"
-elif [ -f "../marmot" ]; then
-    MARMOT_BIN="../marmot"
+# Find or build marmot-v2 binary
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_ROOT/marmot-v2" ]; then
+    MARMOT_BIN="$REPO_ROOT/marmot-v2"
 else
-    echo "Building marmot..."
-    cd "$(dirname "$0")/.."
+    echo "Building marmot-v2..."
+    cd "$REPO_ROOT"
     go build -o marmot-v2 .
-    MARMOT_BIN="./marmot-v2"
+    MARMOT_BIN="$REPO_ROOT/marmot-v2"
+    echo "✓ Build complete"
 fi
 
 echo "Starting Marmot node ${NODE_ID}..."

--- a/examples/node-1-config.toml
+++ b/examples/node-1-config.toml
@@ -25,7 +25,7 @@ dead_timeout_ms = 10000
 [replication]
 default_write_consistency = "QUORUM"
 default_read_consistency = "LOCAL_ONE"
-write_timeout_ms = 5000
+write_timeout_ms = 300000
 read_timeout_ms = 2000
 
 # Anti-Entropy: Background healing for eventual consistency
@@ -56,8 +56,8 @@ max_retries = 3
 retry_backoff_ms = 100
 
 [coordinator]
-prepare_timeout_ms = 2000
-commit_timeout_ms = 2000
+prepare_timeout_ms = 120000
+commit_timeout_ms = 120000
 abort_timeout_ms = 2000
 intent_ttl_ms = 60000      # MutationGuard TTL (60 seconds)
 max_guard_rows = 65536     # Max rows for hash list guards (64K)

--- a/examples/node-2-config.toml
+++ b/examples/node-2-config.toml
@@ -25,7 +25,7 @@ dead_timeout_ms = 10000
 [replication]
 default_write_consistency = "QUORUM"
 default_read_consistency = "LOCAL_ONE"
-write_timeout_ms = 5000
+write_timeout_ms = 300000
 read_timeout_ms = 2000
 
 # Anti-Entropy: Background healing for eventual consistency
@@ -56,8 +56,8 @@ max_retries = 3
 retry_backoff_ms = 100
 
 [coordinator]
-prepare_timeout_ms = 2000
-commit_timeout_ms = 2000
+prepare_timeout_ms = 120000
+commit_timeout_ms = 120000
 abort_timeout_ms = 2000
 intent_ttl_ms = 60000      # MutationGuard TTL (60 seconds)
 max_guard_rows = 65536     # Max rows for hash list guards (64K)

--- a/examples/node-3-config.toml
+++ b/examples/node-3-config.toml
@@ -25,7 +25,7 @@ dead_timeout_ms = 10000
 [replication]
 default_write_consistency = "QUORUM"
 default_read_consistency = "LOCAL_ONE"
-write_timeout_ms = 5000
+write_timeout_ms = 300000
 read_timeout_ms = 2000
 
 # Anti-Entropy: Background healing for eventual consistency
@@ -56,8 +56,8 @@ max_retries = 3
 retry_backoff_ms = 100
 
 [coordinator]
-prepare_timeout_ms = 2000
-commit_timeout_ms = 2000
+prepare_timeout_ms = 120000
+commit_timeout_ms = 120000
 abort_timeout_ms = 2000
 intent_ttl_ms = 60000      # MutationGuard TTL (60 seconds)
 max_guard_rows = 65536     # Max rows for hash list guards (64K)

--- a/examples/run-cluster.sh
+++ b/examples/run-cluster.sh
@@ -11,6 +11,11 @@ echo "=== Marmot v2.0 Example Cluster ==="
 echo "Starting 3-node cluster with full database replication"
 echo ""
 
+# Kill any existing marmot processes
+echo "Stopping any existing marmot processes..."
+pkill -f "marmot-v2" 2>/dev/null || true
+sleep 1
+
 # Clean up old data
 echo "Cleaning up old data..."
 rm -rf /tmp/marmot-node-*

--- a/examples/run-single-node.sh
+++ b/examples/run-single-node.sh
@@ -10,6 +10,12 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 echo "=== Marmot v2.0 Single Node ==="
 echo ""
 
+# Kill any existing marmot processes
+echo "Stopping any existing marmot processes..."
+pkill -f "marmot-v2" 2>/dev/null || true
+lsof -ti:3306 -ti:8080 2>/dev/null | xargs kill 2>/dev/null || true
+sleep 1
+
 # Clean up old data
 echo "Cleaning up old data..."
 rm -rf /tmp/marmot-single
@@ -98,11 +104,11 @@ TOML
 
 echo "✓ Configuration created"
 
-# Build marmot if needed
-if [ ! -f "$REPO_ROOT/marmot" ]; then
-    echo "Building marmot..."
+# Build marmot-v2 if needed
+if [ ! -f "$REPO_ROOT/marmot-v2" ]; then
+    echo "Building marmot-v2..."
     cd "$REPO_ROOT"
-    go build -o marmot .
+    go build -o marmot-v2 .
     echo "✓ Build complete"
 fi
 
@@ -117,7 +123,7 @@ trap cleanup EXIT
 
 echo ""
 echo "Starting Marmot single node..."
-"$REPO_ROOT/marmot" --config /tmp/marmot-single/config.toml > /tmp/marmot-single/marmot.log 2>&1 &
+"$REPO_ROOT/marmot-v2" --config /tmp/marmot-single/config.toml > /tmp/marmot-single/marmot.log 2>&1 &
 pid=$!
 
 sleep 2

--- a/examples/start-seed.sh
+++ b/examples/start-seed.sh
@@ -24,11 +24,14 @@ echo "gRPC Port:   ${GRPC_PORT}"
 echo "Data Dir:    ${DATA_DIR}"
 echo ""
 
-# Clean up previous data (optional)
-if [ -d "${DATA_DIR}" ]; then
-    echo "Cleaning up previous data directory..."
-    rm -rf "${DATA_DIR}"
-fi
+# Kill any existing marmot processes on our ports
+echo "Stopping any existing processes on ports ${MYSQL_PORT}, ${GRPC_PORT}..."
+lsof -ti:${MYSQL_PORT} -ti:${GRPC_PORT} 2>/dev/null | xargs kill 2>/dev/null || true
+sleep 1
+
+# Clean up previous data
+echo "Cleaning up previous data directory..."
+rm -rf "${DATA_DIR}"
 
 mkdir -p "${DATA_DIR}"
 
@@ -83,21 +86,18 @@ verbose = true
 format = "console"
 EOF
 
-# Find marmot binary
-MARMOT_BIN=""
-if [ -f "./marmot-v2" ]; then
-    MARMOT_BIN="./marmot-v2"
-elif [ -f "./marmot" ]; then
-    MARMOT_BIN="./marmot"
-elif [ -f "../marmot-v2" ]; then
-    MARMOT_BIN="../marmot-v2"
-elif [ -f "../marmot" ]; then
-    MARMOT_BIN="../marmot"
+# Find or build marmot-v2 binary
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_ROOT/marmot-v2" ]; then
+    MARMOT_BIN="$REPO_ROOT/marmot-v2"
 else
-    echo "Building marmot..."
-    cd "$(dirname "$0")/.."
+    echo "Building marmot-v2..."
+    cd "$REPO_ROOT"
     go build -o marmot-v2 .
-    MARMOT_BIN="./marmot-v2"
+    MARMOT_BIN="$REPO_ROOT/marmot-v2"
+    echo "✓ Build complete"
 fi
 
 echo "Starting seed node..."

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,8 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/net v0.46.1-0.20251013234738-63d1a5100f82 // indirect
 	golang.org/x/sys v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,10 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=

--- a/marmot.go
+++ b/marmot.go
@@ -291,6 +291,7 @@ func main() {
 		replicator,
 		localReplicator,
 		writeTimeout,
+		clock,
 	)
 
 	// Initialize LocalReader for ReadCoordinator

--- a/protocol/parser.go
+++ b/protocol/parser.go
@@ -227,6 +227,17 @@ func IsMutation(stmt Statement) bool {
 	}
 }
 
+// IsDML returns true if the statement is a row-level DML operation
+// (INSERT, UPDATE, DELETE, REPLACE) that requires row key tracking
+func IsDML(stmt Statement) bool {
+	switch stmt.Type {
+	case StatementInsert, StatementUpdate, StatementDelete, StatementReplace:
+		return true
+	default:
+		return false
+	}
+}
+
 // IsTransactionControl returns true if the statement is transaction control
 func IsTransactionControl(stmt Statement) bool {
 	switch stmt.Type {

--- a/protocol/prepared_stmt_test.go
+++ b/protocol/prepared_stmt_test.go
@@ -1,0 +1,297 @@
+package protocol
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+func TestParseParamValue_TINY(t *testing.T) {
+	// MYSQL_TYPE_TINY = 0x01
+	payload := []byte{42}
+	offset, val, err := parseParamValue(payload, 0, 0x01)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if offset != 1 {
+		t.Errorf("Expected offset 1, got %d", offset)
+	}
+	if val != int8(42) {
+		t.Errorf("Expected 42, got %v", val)
+	}
+}
+
+func TestParseParamValue_SHORT(t *testing.T) {
+	// MYSQL_TYPE_SHORT = 0x02
+	payload := make([]byte, 2)
+	binary.LittleEndian.PutUint16(payload, 1234)
+	offset, val, err := parseParamValue(payload, 0, 0x02)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if offset != 2 {
+		t.Errorf("Expected offset 2, got %d", offset)
+	}
+	if val != int16(1234) {
+		t.Errorf("Expected 1234, got %v", val)
+	}
+}
+
+func TestParseParamValue_LONG(t *testing.T) {
+	// MYSQL_TYPE_LONG = 0x03
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, 123456)
+	offset, val, err := parseParamValue(payload, 0, 0x03)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if offset != 4 {
+		t.Errorf("Expected offset 4, got %d", offset)
+	}
+	if val != int32(123456) {
+		t.Errorf("Expected 123456, got %v", val)
+	}
+}
+
+func TestParseParamValue_LONGLONG(t *testing.T) {
+	// MYSQL_TYPE_LONGLONG = 0x08
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint64(payload, 9876543210)
+	offset, val, err := parseParamValue(payload, 0, 0x08)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if offset != 8 {
+		t.Errorf("Expected offset 8, got %d", offset)
+	}
+	if val != int64(9876543210) {
+		t.Errorf("Expected 9876543210, got %v", val)
+	}
+}
+
+func TestParseParamValue_FLOAT(t *testing.T) {
+	// MYSQL_TYPE_FLOAT = 0x04
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, math.Float32bits(3.14))
+	offset, val, err := parseParamValue(payload, 0, 0x04)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if offset != 4 {
+		t.Errorf("Expected offset 4, got %d", offset)
+	}
+	floatVal, ok := val.(float32)
+	if !ok {
+		t.Fatalf("Expected float32, got %T", val)
+	}
+	if math.Abs(float64(floatVal-3.14)) > 0.001 {
+		t.Errorf("Expected ~3.14, got %v", val)
+	}
+}
+
+func TestParseParamValue_DOUBLE(t *testing.T) {
+	// MYSQL_TYPE_DOUBLE = 0x05
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint64(payload, math.Float64bits(3.14159265))
+	offset, val, err := parseParamValue(payload, 0, 0x05)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if offset != 8 {
+		t.Errorf("Expected offset 8, got %d", offset)
+	}
+	floatVal, ok := val.(float64)
+	if !ok {
+		t.Fatalf("Expected float64, got %T", val)
+	}
+	if math.Abs(floatVal-3.14159265) > 0.0000001 {
+		t.Errorf("Expected ~3.14159265, got %v", val)
+	}
+}
+
+func TestParseParamValue_STRING(t *testing.T) {
+	// MYSQL_TYPE_VAR_STRING = 0xFD (length-prefixed string)
+	str := "hello world"
+	payload := make([]byte, 1+len(str))
+	payload[0] = byte(len(str)) // Length prefix
+	copy(payload[1:], str)
+
+	offset, val, err := parseParamValue(payload, 0, 0xFD)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if offset != 1+len(str) {
+		t.Errorf("Expected offset %d, got %d", 1+len(str), offset)
+	}
+	// VAR_STRING returns []byte
+	if byteVal, ok := val.([]byte); ok {
+		if string(byteVal) != str {
+			t.Errorf("Expected %q, got %q", str, string(byteVal))
+		}
+	} else if strVal, ok := val.(string); ok {
+		if strVal != str {
+			t.Errorf("Expected %q, got %q", str, strVal)
+		}
+	} else {
+		t.Errorf("Expected string or []byte, got %T: %v", val, val)
+	}
+}
+
+func TestParseParamValue_NULL(t *testing.T) {
+	// MYSQL_TYPE_NULL = 0x06
+	offset, val, err := parseParamValue([]byte{}, 0, 0x06)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if offset != 0 {
+		t.Errorf("Expected offset 0, got %d", offset)
+	}
+	if val != nil {
+		t.Errorf("Expected nil, got %v", val)
+	}
+}
+
+func TestBuildQueryWithParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  string
+		params []interface{}
+		want   string
+	}{
+		{
+			name:   "Single int param",
+			query:  "SELECT * FROM users WHERE id = ?",
+			params: []interface{}{int64(42)},
+			want:   "SELECT * FROM users WHERE id = 42",
+		},
+		{
+			name:   "Single string param",
+			query:  "SELECT * FROM users WHERE name = ?",
+			params: []interface{}{"Alice"},
+			want:   "SELECT * FROM users WHERE name = 'Alice'",
+		},
+		{
+			name:   "Multiple params",
+			query:  "INSERT INTO users (id, name, age) VALUES (?, ?, ?)",
+			params: []interface{}{int64(1), "Bob", int64(30)},
+			want:   "INSERT INTO users (id, name, age) VALUES (1, 'Bob', 30)",
+		},
+		{
+			name:   "NULL param",
+			query:  "UPDATE users SET email = ? WHERE id = ?",
+			params: []interface{}{nil, int64(1)},
+			want:   "UPDATE users SET email = NULL WHERE id = 1",
+		},
+		{
+			name:   "String with quotes",
+			query:  "SELECT * FROM users WHERE bio = ?",
+			params: []interface{}{"He said \"hello\""},
+			want:   "SELECT * FROM users WHERE bio = 'He said \\\"hello\\\"'",
+		},
+		{
+			name:   "Float param",
+			query:  "UPDATE products SET price = ? WHERE id = ?",
+			params: []interface{}{float64(19.99), int64(5)},
+			want:   "UPDATE products SET price = 19.990000 WHERE id = 5",
+		},
+		{
+			name:   "Question mark in string literal should be preserved",
+			query:  "SELECT * FROM faq WHERE question = '?' AND id = ?",
+			params: []interface{}{int64(1)},
+			want:   "SELECT * FROM faq WHERE question = '?' AND id = 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildQueryWithParams(tt.query, tt.params)
+			if got != tt.want {
+				t.Errorf("buildQueryWithParams() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountPlaceholders(t *testing.T) {
+	tests := []struct {
+		query string
+		want  int
+	}{
+		{"SELECT * FROM users WHERE id = ?", 1},
+		{"INSERT INTO users VALUES (?, ?, ?)", 3},
+		{"SELECT * FROM users", 0},
+		{"SELECT * FROM faq WHERE question = '?' AND id = ?", 1}, // ? in string
+		{"UPDATE users SET name = '?' WHERE id = ?", 1},          // ? in string
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got := countPlaceholders(tt.query)
+			if got != tt.want {
+				t.Errorf("countPlaceholders() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreparedStatement_ParamTypesCaching(t *testing.T) {
+	// This tests that ParamTypes can be cached and reused
+	stmt := &PreparedStatement{
+		ID:         1,
+		Query:      "SELECT * FROM users WHERE id = ?",
+		ParamCount: 1,
+	}
+
+	// Simulate first execution with newParamsBoundFlag = 1
+	paramTypes := []byte{0x08, 0x00} // LONGLONG, unsigned flag
+	stmt.ParamTypes = paramTypes
+
+	// Verify cached
+	if len(stmt.ParamTypes) != 2 {
+		t.Errorf("Expected ParamTypes length 2, got %d", len(stmt.ParamTypes))
+	}
+	if stmt.ParamTypes[0] != 0x08 {
+		t.Errorf("Expected ParamTypes[0] = 0x08, got %02x", stmt.ParamTypes[0])
+	}
+
+	// Simulate subsequent execution with newParamsBoundFlag = 0
+	// Should use cached types
+	cachedType := stmt.ParamTypes[0]
+	if cachedType != 0x08 {
+		t.Errorf("Cached param type should be 0x08 (LONGLONG), got %02x", cachedType)
+	}
+}
+
+func BenchmarkBuildQueryWithParams(b *testing.B) {
+	query := "INSERT INTO sbtest1 (id, k, c, pad) VALUES (?, ?, ?, ?)"
+	params := []interface{}{
+		int64(12345),
+		int64(67890),
+		"00000000000000000000000000000000",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buildQueryWithParams(query, params)
+	}
+}
+
+func BenchmarkParseParamValue_LONGLONG(b *testing.B) {
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint64(payload, 9876543210)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parseParamValue(payload, 0, 0x08)
+	}
+}
+
+func BenchmarkCountPlaceholders(b *testing.B) {
+	query := "INSERT INTO sbtest1 (id, k, c, pad) VALUES (?, ?, ?, ?)"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		countPlaceholders(query)
+	}
+}

--- a/protocol/query/rules/create_table.go
+++ b/protocol/query/rules/create_table.go
@@ -1,0 +1,89 @@
+package rules
+
+import (
+	"strings"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+// CreateTableRule transforms MySQL CREATE TABLE syntax to SQLite-compatible syntax
+// Handles:
+// - AUTO_INCREMENT → removed (SQLite INTEGER PRIMARY KEY auto-increments implicitly)
+// - UNSIGNED → removed (SQLite doesn't support UNSIGNED)
+// - ENGINE = innodb → removed (SQLite has no storage engines)
+// - MySQL comments /*! ... */ → removed
+type CreateTableRule struct{}
+
+func (r *CreateTableRule) Name() string  { return "CreateTable" }
+func (r *CreateTableRule) Priority() int { return 5 } // Run early, before other rules
+
+func (r *CreateTableRule) ApplyAST(stmt sqlparser.Statement) (sqlparser.Statement, bool, error) {
+	create, ok := stmt.(*sqlparser.CreateTable)
+	if !ok {
+		return stmt, false, nil
+	}
+
+	modified := false
+
+	if create.TableSpec != nil {
+		// Process columns
+		for _, col := range create.TableSpec.Columns {
+			if col.Type != nil {
+				// Remove UNSIGNED
+				if col.Type.Unsigned {
+					col.Type.Unsigned = false
+					modified = true
+				}
+
+				// Remove AUTO_INCREMENT
+				// SQLite's INTEGER PRIMARY KEY automatically becomes ROWID alias
+				if col.Type.Options != nil && col.Type.Options.Autoincrement {
+					col.Type.Options.Autoincrement = false
+					modified = true
+				}
+			}
+		}
+
+		// Clear table options (ENGINE, CHARSET, etc.)
+		if len(create.TableSpec.Options) > 0 {
+			create.TableSpec.Options = nil
+			modified = true
+		}
+	}
+
+	if !modified {
+		return stmt, false, nil
+	}
+
+	return create, true, nil
+}
+
+func (r *CreateTableRule) ApplyPattern(sql string) (string, bool, error) {
+	// Remove MySQL comment hints like /*! ENGINE = innodb */
+	// These are the only pattern-based transforms since AST handles the rest
+	upperSQL := strings.ToUpper(sql)
+	if !strings.Contains(upperSQL, "/*!") {
+		return sql, false, nil
+	}
+
+	// Remove /*! ... */ comments
+	result := sql
+	for {
+		start := strings.Index(result, "/*!")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start:], "*/")
+		if end == -1 {
+			break
+		}
+		result = result[:start] + result[start+end+2:]
+	}
+
+	// Clean up multiple spaces
+	for strings.Contains(result, "  ") {
+		result = strings.ReplaceAll(result, "  ", " ")
+	}
+
+	return strings.TrimSpace(result), result != sql, nil
+}

--- a/protocol/query/transpiler.go
+++ b/protocol/query/transpiler.go
@@ -27,6 +27,7 @@ func NewTranspiler(cacheSize int) (*Transpiler, error) {
 	}
 
 	ruleSet := RuleSet{
+		&rules.CreateTableRule{},
 		&rules.TransactionSyntaxRule{},
 		&rules.InsertIgnoreRule{},
 		&rules.ReplaceIntoRule{},

--- a/scripts/benchmark-quick.sh
+++ b/scripts/benchmark-quick.sh
@@ -32,7 +32,10 @@ echo -e "${GREEN}✓ Built${NC}"
 
 # Cleanup
 echo -e "${YELLOW}[2/4] Cleaning up...${NC}"
-pkill -f "marmot-v2" || true
+pkill -9 -f "marmot-v2" 2>/dev/null || true
+for port in 3307 3308 3309 8081 8082 8083; do
+    lsof -ti:$port 2>/dev/null | xargs kill -9 2>/dev/null || true
+done
 sleep 2
 rm -rf /tmp/marmot-node-* || true
 
@@ -84,7 +87,12 @@ $YCSB_BIN run mysql \
     -p threadcount=10
 
 # Cleanup
-pkill -f "marmot-v2" || true
+echo ""
+echo -e "${YELLOW}Cleaning up...${NC}"
+pkill -9 -f "marmot-v2" 2>/dev/null || true
+for port in 3307 3308 3309 8081 8082 8083; do
+    lsof -ti:$port 2>/dev/null | xargs kill -9 2>/dev/null || true
+done
 
 echo ""
 echo -e "${GREEN}✓ Quick benchmark complete!${NC}"

--- a/scripts/benchmark-sysbench.sh
+++ b/scripts/benchmark-sysbench.sh
@@ -1,0 +1,370 @@
+#!/bin/bash
+set -e
+
+# Marmot Sysbench Benchmark
+# Based on CockroachDB/TiDB benchmark methodology
+# Tests OLTP workloads with varying thread counts
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESULTS_DIR="/tmp/marmot-sysbench-results"
+
+# Custom sysbench built against mariadb-connector-c 3.3.8 (without forced SSL)
+# To rebuild: see scripts/README.md or run make sysbench-setup
+SYSBENCH_BIN="${SYSBENCH_BIN:-/tmp/sysbench-custom/bin/sysbench}"
+MARIADB_LIB="${MARIADB_LIB:-/tmp/mariadb-custom/lib/mariadb}"
+
+# Configuration - tune these for your machine
+TABLES=${TABLES:-4}              # Number of tables
+TABLE_SIZE=${TABLE_SIZE:-10000}  # Rows per table
+TIME=${TIME:-60}                 # Seconds per test
+REPORT_INTERVAL=${REPORT_INTERVAL:-10}  # Report every N seconds
+MYSQL_HOST=${MYSQL_HOST:-127.0.0.1}
+MYSQL_PORT=${MYSQL_PORT:-3307}
+MYSQL_USER=${MYSQL_USER:-root}
+MYSQL_DB=${MYSQL_DB:-marmot}
+
+# Thread counts to test (CockroachDB style)
+THREAD_COUNTS=${THREAD_COUNTS:-"1 4 8 16 32"}
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+print_header() {
+    echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║         Marmot Sysbench Benchmark Suite                    ║${NC}"
+    echo -e "${BLUE}║     OLTP Performance Testing (CockroachDB-style)          ║${NC}"
+    echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+check_sysbench() {
+    echo -e "${YELLOW}[1/6] Checking sysbench installation...${NC}"
+
+    # Check for custom sysbench (required for macOS due to mariadb-connector SSL issue)
+    if [ -x "$SYSBENCH_BIN" ] && [ -d "$MARIADB_LIB" ]; then
+        export DYLD_LIBRARY_PATH="$MARIADB_LIB:$DYLD_LIBRARY_PATH"
+        local version=$("$SYSBENCH_BIN" --version)
+        echo -e "${GREEN}✓ Custom $version${NC}"
+        echo -e "${GREEN}  Using: $SYSBENCH_BIN${NC}"
+        # Define sysbench function for rest of script
+        sysbench() { "$SYSBENCH_BIN" "$@"; }
+        export -f sysbench
+        return 0
+    fi
+
+    # Fall back to system sysbench
+    if command -v sysbench &> /dev/null; then
+        local version=$(sysbench --version)
+        echo -e "${YELLOW}⚠ Using system sysbench: $version${NC}"
+        echo -e "${YELLOW}  Note: May fail on macOS due to SSL requirements${NC}"
+        return 0
+    fi
+
+    echo -e "${RED}✗ sysbench not found.${NC}"
+    echo ""
+    echo "To build custom sysbench (recommended for macOS):"
+    echo "  # Clone and build mariadb-connector-c 3.3.8"
+    echo "  git clone --depth 1 --branch v3.3.8 https://github.com/mariadb-corporation/mariadb-connector-c.git /tmp/mariadb-connector"
+    echo "  cmake -S /tmp/mariadb-connector -B /tmp/mariadb-connector/build -DCMAKE_INSTALL_PREFIX=/tmp/mariadb-custom -DWITH_EXTERNAL_ZLIB=ON"
+    echo "  cmake --build /tmp/mariadb-connector/build && cmake --install /tmp/mariadb-connector/build"
+    echo ""
+    echo "  # Clone and build sysbench"
+    echo "  git clone --depth 1 https://github.com/akopytov/sysbench.git /tmp/sysbench-build/sysbench"
+    echo "  cd /tmp/sysbench-build/sysbench && ./autogen.sh"
+    echo "  ./configure --with-mysql --with-mysql-includes=/tmp/mariadb-custom/include/mariadb \\"
+    echo "    --with-mysql-libs=/tmp/mariadb-custom/lib/mariadb --prefix=/tmp/sysbench-custom --with-system-luajit"
+    echo "  make && make install"
+    echo ""
+    echo "Or install system sysbench (may have SSL issues):"
+    echo "  brew install sysbench  (macOS)"
+    echo "  apt install sysbench   (Ubuntu/Debian)"
+    exit 1
+}
+
+build_marmot() {
+    echo ""
+    echo -e "${YELLOW}[2/6] Building Marmot with preupdate hook support...${NC}"
+    cd "$REPO_ROOT"
+    go build -tags=sqlite_preupdate_hook -o marmot-v2 .
+    echo -e "${GREEN}✓ Marmot built successfully${NC}"
+}
+
+cleanup() {
+    echo ""
+    echo -e "${YELLOW}[3/6] Cleaning up existing processes...${NC}"
+    pkill -9 -f "marmot-v2" 2>/dev/null || true
+    for port in 3307 3308 3309 8081 8082 8083; do
+        lsof -ti:$port 2>/dev/null | xargs kill -9 2>/dev/null || true
+    done
+    sleep 2
+    rm -rf /tmp/marmot-node-* 2>/dev/null || true
+    echo -e "${GREEN}✓ Cleanup complete${NC}"
+}
+
+start_cluster() {
+    echo ""
+    echo -e "${YELLOW}[4/6] Starting 3-node cluster...${NC}"
+    cd "$REPO_ROOT"
+
+    # Start all nodes quickly so they can discover each other
+    ./marmot-v2 --config examples/node-1-config.toml > /tmp/node1.log 2>&1 &
+    sleep 1
+    ./marmot-v2 --config examples/node-2-config.toml > /tmp/node2.log 2>&1 &
+    sleep 1
+    ./marmot-v2 --config examples/node-3-config.toml > /tmp/node3.log 2>&1 &
+
+    # Wait for cluster to form and stabilize
+    echo "  Waiting for cluster to form..."
+    sleep 10
+
+    # Verify all ports are listening
+    for port in 3307 3308 3309; do
+        if ! lsof -ti:$port >/dev/null 2>&1; then
+            echo -e "${RED}✗ Port $port not listening${NC}"
+            exit 1
+        fi
+    done
+
+    # Additional wait for gossip convergence
+    sleep 5
+    echo -e "${GREEN}✓ Cluster ready (ports 3307, 3308, 3309)${NC}"
+}
+
+prepare_data() {
+    echo ""
+    echo -e "${YELLOW}[5/6] Preparing sysbench data...${NC}"
+    echo "  Tables: $TABLES"
+    echo "  Rows per table: $TABLE_SIZE"
+    echo "  Total rows: $((TABLES * TABLE_SIZE))"
+    echo ""
+
+    mkdir -p "$RESULTS_DIR"
+
+    # Prepare tables
+    sysbench oltp_read_write \
+        --db-driver=mysql \
+        --mysql-host=$MYSQL_HOST \
+        --mysql-port=$MYSQL_PORT \
+        --mysql-user=$MYSQL_USER \
+        --mysql-db=$MYSQL_DB \
+        --tables=$TABLES \
+        --table-size=$TABLE_SIZE \
+        prepare 2>&1 | tee "$RESULTS_DIR/prepare.log"
+
+    echo -e "${GREEN}✓ Data prepared${NC}"
+}
+
+run_workload() {
+    local workload=$1
+    local threads=$2
+    local label=$3
+
+    echo ""
+    echo -e "${CYAN}Running: $label (threads=$threads, time=${TIME}s)${NC}"
+
+    sysbench $workload \
+        --db-driver=mysql \
+        --mysql-host=$MYSQL_HOST \
+        --mysql-port=$MYSQL_PORT \
+        --mysql-user=$MYSQL_USER \
+        --mysql-db=$MYSQL_DB \
+        --tables=$TABLES \
+        --table-size=$TABLE_SIZE \
+        --threads=$threads \
+        --time=$TIME \
+        --report-interval=$REPORT_INTERVAL \
+        run 2>&1 | tee "$RESULTS_DIR/${workload}_t${threads}.log"
+}
+
+extract_metrics() {
+    local logfile=$1
+    local tps=$(grep "transactions:" "$logfile" | awk '{print $3}' | tr -d '(')
+    local qps=$(grep "queries:" "$logfile" | awk '{print $3}' | tr -d '(')
+    local lat_avg=$(grep "avg:" "$logfile" | tail -1 | awk '{print $2}')
+    local lat_p95=$(grep "95th percentile:" "$logfile" | awk '{print $3}')
+    local lat_p99=$(grep "99th percentile:" "$logfile" 2>/dev/null | awk '{print $3}')
+    echo "$tps,$qps,$lat_avg,$lat_p95,$lat_p99"
+}
+
+run_benchmark() {
+    echo ""
+    echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  Running Benchmarks${NC}"
+    echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+
+    # Initialize CSV results
+    echo "workload,threads,tps,qps,lat_avg_ms,lat_p95_ms,lat_p99_ms" > "$RESULTS_DIR/results.csv"
+
+    # Test 1: OLTP Read/Write (mixed workload - most important)
+    echo ""
+    echo -e "${YELLOW}═══ Test 1: OLTP Read/Write (Mixed) ═══${NC}"
+    for threads in $THREAD_COUNTS; do
+        run_workload "oltp_read_write" $threads "OLTP Read/Write"
+        metrics=$(extract_metrics "$RESULTS_DIR/oltp_read_write_t${threads}.log")
+        echo "oltp_read_write,$threads,$metrics" >> "$RESULTS_DIR/results.csv"
+    done
+
+    # Test 2: OLTP Read Only
+    echo ""
+    echo -e "${YELLOW}═══ Test 2: OLTP Read Only ═══${NC}"
+    for threads in $THREAD_COUNTS; do
+        run_workload "oltp_read_only" $threads "OLTP Read Only"
+        metrics=$(extract_metrics "$RESULTS_DIR/oltp_read_only_t${threads}.log")
+        echo "oltp_read_only,$threads,$metrics" >> "$RESULTS_DIR/results.csv"
+    done
+
+    # Test 3: OLTP Write Only
+    echo ""
+    echo -e "${YELLOW}═══ Test 3: OLTP Write Only ═══${NC}"
+    for threads in $THREAD_COUNTS; do
+        run_workload "oltp_write_only" $threads "OLTP Write Only"
+        metrics=$(extract_metrics "$RESULTS_DIR/oltp_write_only_t${threads}.log")
+        echo "oltp_write_only,$threads,$metrics" >> "$RESULTS_DIR/results.csv"
+    done
+
+    # Test 4: Point Select (pure read latency)
+    echo ""
+    echo -e "${YELLOW}═══ Test 4: Point Select ═══${NC}"
+    for threads in $THREAD_COUNTS; do
+        run_workload "oltp_point_select" $threads "Point Select"
+        metrics=$(extract_metrics "$RESULTS_DIR/oltp_point_select_t${threads}.log")
+        echo "oltp_point_select,$threads,$metrics" >> "$RESULTS_DIR/results.csv"
+    done
+
+    # Test 5: Insert Only (pure write throughput)
+    echo ""
+    echo -e "${YELLOW}═══ Test 5: Insert Only ═══${NC}"
+    for threads in $THREAD_COUNTS; do
+        run_workload "oltp_insert" $threads "Insert Only"
+        metrics=$(extract_metrics "$RESULTS_DIR/oltp_insert_t${threads}.log")
+        echo "oltp_insert,$threads,$metrics" >> "$RESULTS_DIR/results.csv"
+    done
+
+    # Test 6: Update Index (write contention)
+    echo ""
+    echo -e "${YELLOW}═══ Test 6: Update Index ═══${NC}"
+    for threads in $THREAD_COUNTS; do
+        run_workload "oltp_update_index" $threads "Update Index"
+        metrics=$(extract_metrics "$RESULTS_DIR/oltp_update_index_t${threads}.log")
+        echo "oltp_update_index,$threads,$metrics" >> "$RESULTS_DIR/results.csv"
+    done
+}
+
+cleanup_data() {
+    echo ""
+    echo -e "${YELLOW}Cleaning up sysbench tables...${NC}"
+    sysbench oltp_read_write \
+        --db-driver=mysql \
+        --mysql-host=$MYSQL_HOST \
+        --mysql-port=$MYSQL_PORT \
+        --mysql-user=$MYSQL_USER \
+        --mysql-db=$MYSQL_DB \
+        --tables=$TABLES \
+        cleanup 2>/dev/null || true
+}
+
+show_results() {
+    echo ""
+    echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║                    BENCHMARK RESULTS                       ║${NC}"
+    echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo -e "${GREEN}Configuration:${NC}"
+    echo "  Tables: $TABLES"
+    echo "  Rows per table: $TABLE_SIZE"
+    echo "  Test duration: ${TIME}s per workload"
+    echo "  Thread counts: $THREAD_COUNTS"
+    echo ""
+
+    echo -e "${GREEN}Results Summary (CSV):${NC}"
+    echo ""
+    column -t -s',' "$RESULTS_DIR/results.csv"
+    echo ""
+
+    # Find best TPS for each workload
+    echo -e "${GREEN}Peak Performance:${NC}"
+    for workload in oltp_read_write oltp_read_only oltp_write_only oltp_point_select oltp_insert oltp_update_index; do
+        local best=$(grep "^$workload," "$RESULTS_DIR/results.csv" | sort -t',' -k3 -rn | head -1)
+        if [ -n "$best" ]; then
+            local threads=$(echo "$best" | cut -d',' -f2)
+            local tps=$(echo "$best" | cut -d',' -f3)
+            local lat=$(echo "$best" | cut -d',' -f5)
+            printf "  %-20s %6s TPS @ %2s threads (P95: %sms)\n" "$workload:" "$tps" "$threads" "$lat"
+        fi
+    done
+}
+
+print_usage() {
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  --tables N        Number of tables (default: 4)"
+    echo "  --table-size N    Rows per table (default: 10000)"
+    echo "  --time N          Seconds per test (default: 60)"
+    echo "  --threads 'N ...' Thread counts to test (default: '1 4 8 16 32')"
+    echo "  --port N          MySQL port (default: 3307)"
+    echo "  --skip-cluster    Don't start cluster (use existing)"
+    echo "  --help            Show this help"
+    echo ""
+    echo "Environment variables:"
+    echo "  TABLES, TABLE_SIZE, TIME, THREAD_COUNTS, MYSQL_PORT"
+    echo ""
+    echo "Examples:"
+    echo "  $0                           # Default settings"
+    echo "  $0 --tables 8 --table-size 50000 --time 120"
+    echo "  $0 --threads '1 2 4 8 16 32 64'"
+    echo "  TABLES=16 TABLE_SIZE=100000 $0"
+}
+
+# Parse arguments
+SKIP_CLUSTER=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --tables) TABLES="$2"; shift 2 ;;
+        --table-size) TABLE_SIZE="$2"; shift 2 ;;
+        --time) TIME="$2"; shift 2 ;;
+        --threads) THREAD_COUNTS="$2"; shift 2 ;;
+        --port) MYSQL_PORT="$2"; shift 2 ;;
+        --skip-cluster) SKIP_CLUSTER=true; shift ;;
+        --help) print_usage; exit 0 ;;
+        *) echo "Unknown option: $1"; print_usage; exit 1 ;;
+    esac
+done
+
+main() {
+    cd "$REPO_ROOT"
+    print_header
+
+    check_sysbench
+
+    if [ "$SKIP_CLUSTER" = false ]; then
+        build_marmot
+        cleanup
+        start_cluster
+    fi
+
+    prepare_data
+    run_benchmark
+    show_results
+
+    if [ "$SKIP_CLUSTER" = false ]; then
+        cleanup_data
+        cleanup
+    fi
+
+    echo ""
+    echo -e "${GREEN}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${GREEN}║  Benchmark Complete!                                       ║${NC}"
+    echo -e "${GREEN}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo "Full results: $RESULTS_DIR/results.csv"
+    echo "Individual logs: $RESULTS_DIR/*.log"
+}
+
+main "$@"

--- a/scripts/sysbench-test.sh
+++ b/scripts/sysbench-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Sysbench test script for Marmot
+# Usage: ./scripts/sysbench-test.sh [threads] [time]
+#   threads: number of threads (default: 4)
+#   time: test duration in seconds (default: 60)
+
+set -e
+
+THREADS=${1:-4}
+TIME=${2:-60}
+TABLE_SIZE=10000
+TABLES=1
+MYSQL_HOST=127.0.0.1
+MYSQL_PORT=3307
+MYSQL_USER=root
+MYSQL_DB=marmot
+
+# Path setup
+SYSBENCH_BIN="/tmp/sysbench-custom/bin/sysbench"
+SYSBENCH_LUA="/tmp/sysbench-custom/share/sysbench/oltp_read_write.lua"
+MARIADB_LIB="/tmp/mariadb-custom/lib/mariadb"
+
+if [[ ! -f "$SYSBENCH_BIN" ]]; then
+    echo "ERROR: sysbench not found at $SYSBENCH_BIN"
+    echo "Run ./scripts/benchmark-sysbench.sh once to install it"
+    exit 1
+fi
+
+export DYLD_LIBRARY_PATH="$MARIADB_LIB:$DYLD_LIBRARY_PATH"
+
+COMMON_OPTS="--mysql-host=$MYSQL_HOST --mysql-port=$MYSQL_PORT --mysql-user=$MYSQL_USER --mysql-db=$MYSQL_DB --tables=$TABLES --table_size=$TABLE_SIZE"
+
+echo "=== Sysbench Test ==="
+echo "Threads: $THREADS"
+echo "Time: ${TIME}s"
+echo "Table size: $TABLE_SIZE"
+echo ""
+
+# Cleanup any existing tables
+echo "=== Cleanup ==="
+$SYSBENCH_BIN $SYSBENCH_LUA $COMMON_OPTS cleanup 2>/dev/null || true
+
+# Prepare
+echo ""
+echo "=== Prepare ==="
+$SYSBENCH_BIN $SYSBENCH_LUA $COMMON_OPTS --threads=1 prepare
+
+# Run
+echo ""
+echo "=== Run (threads=$THREADS, time=${TIME}s) ==="
+$SYSBENCH_BIN $SYSBENCH_LUA $COMMON_OPTS --threads=$THREADS --time=$TIME --report-interval=5 run
+
+# Cleanup
+echo ""
+echo "=== Cleanup ==="
+$SYSBENCH_BIN $SYSBENCH_LUA $COMMON_OPTS cleanup
+
+echo ""
+echo "=== Done ==="

--- a/scripts/test-ddl-replication.sh
+++ b/scripts/test-ddl-replication.sh
@@ -16,8 +16,12 @@ echo ""
 
 # Clean up any existing processes and data
 echo "Cleaning up old processes and data..."
-pkill -f "marmot-v2" 2>/dev/null || true
-sleep 1
+pkill -9 -f "marmot-v2" 2>/dev/null || true
+for port in 3307 3308 3309 8081 8082 8083; do
+    lsof -ti:$port 2>/dev/null | xargs kill -9 2>/dev/null || true
+done
+sleep 2
+rm -rf /tmp/marmot-node-* 2>/dev/null || true
 
 # Start seed node (node 1)
 echo "Starting seed node (port 8081, mysql 3307)..."

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -322,8 +322,12 @@ echo ""
 
 # Clean up any existing processes and data
 echo "Cleaning up old processes and data..."
-pkill -f "marmot-v2" 2>/dev/null || true
-sleep 1
+pkill -9 -f "marmot-v2" 2>/dev/null || true
+for port in 3307 3308 3309 8081 8082 8083; do
+    lsof -ti:$port 2>/dev/null | xargs kill -9 2>/dev/null || true
+done
+sleep 2
+rm -rf /tmp/marmot-node-* 2>/dev/null || true
 
 # Start 3-node cluster
 echo "Starting 3-node cluster..."

--- a/test/ddl_replication_test.go
+++ b/test/ddl_replication_test.go
@@ -459,6 +459,7 @@ func TestDDLReplicationBasic(t *testing.T) {
 		replicator,
 		replicator,
 		1*time.Second,
+		clock,
 	)
 
 	readCoord := coordinator.NewReadCoordinator(
@@ -550,6 +551,7 @@ func TestDDLWithConcurrentDML(t *testing.T) {
 		replicator,
 		replicator,
 		1*time.Second,
+		clock,
 	)
 
 	readCoord := coordinator.NewReadCoordinator(

--- a/test/verification_test.go
+++ b/test/verification_test.go
@@ -94,7 +94,7 @@ func TestMySQLServerIntegration(t *testing.T) {
 	dbMgr := NewTestDatabaseManager(mvccDB)
 
 	localReplicator := db.NewLocalReplicator(1, dbMgr, clock)
-	writeCoord := coordinator.NewWriteCoordinator(1, nodeProvider, replicator, localReplicator, time.Second)
+	writeCoord := coordinator.NewWriteCoordinator(1, nodeProvider, replicator, localReplicator, time.Second, clock)
 
 	localReader := db.NewLocalReader(dbMgr)
 	readCoord := coordinator.NewReadCoordinator(1, nodeProvider, localReader, time.Second)


### PR DESCRIPTION
Key fixes:
- Fix ReopenDatabase to use create-swap-close pattern, preventing "database is closed" errors during anti-entropy snapshot applies
- Increase hook execution timeout from 5s to configurable LockWaitTimeout (default 50s) to prevent "context deadline exceeded" under load
- Make AbortTransaction delete records instead of UPDATE to ABORTED, reducing storage overhead and simplifying cleanup
- Update GC cleanupStaleTransactions to also DELETE (consistent behavior)

Other changes:
- Add sysbench benchmark scripts for OLTP performance testing
- Add prepared statement tests and CREATE TABLE rule
- Update test helpers to handle deleted aborted transactions
- Various script improvements for cleanup and process management

🤖 Generated with [Claude Code](https://claude.com/claude-code)