### PR TITLE
Feat: Add determinism detection for DML statement replication

### DIFF
--- a/db/db_integration.go
+++ b/db/db_integration.go
@@ -424,6 +424,13 @@ func (mdb *ReplicatedDatabase) GetCachedTableSchema(tableName string) (*TableSch
 	return mdb.schemaCache.GetSchemaFor(tableName)
 }
 
+// GetSchemaCache returns the schema cache for building determinism schemas.
+// Used by coordinator to check if DML statements are deterministic.
+// Returns interface{} to avoid import cycles with coordinator package.
+func (mdb *ReplicatedDatabase) GetSchemaCache() interface{} {
+	return mdb.schemaCache
+}
+
 // ApplyCDCEntries applies CDC data entries to SQLite.
 // Used by CompletedLocalExecution.Commit() to persist data captured during hooks.
 func (mdb *ReplicatedDatabase) ApplyCDCEntries(entries []*IntentEntry) error {

--- a/db/schema_cache_test.go
+++ b/db/schema_cache_test.go
@@ -1,0 +1,185 @@
+//go:build sqlite_preupdate_hook
+// +build sqlite_preupdate_hook
+
+package db
+
+import (
+	"testing"
+
+	"github.com/maxpert/marmot/protocol/determinism"
+)
+
+func TestSchemaCache_BuildDeterminismSchema_WithDefaults(t *testing.T) {
+	cache := NewSchemaCache()
+
+	// Manually add a table with CreateSQL that has non-deterministic DEFAULT
+	cache.Update("events", &TableSchema{
+		TableName: "events",
+		Columns:   []string{"id", "name", "created_at"},
+		CreateSQL: `CREATE TABLE events (
+			id INTEGER PRIMARY KEY,
+			name TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+	})
+
+	schema := cache.BuildDeterminismSchema()
+	if schema == nil {
+		t.Fatal("BuildDeterminismSchema returned nil")
+	}
+
+	// Check that the schema was built correctly
+	table, ok := schema.Tables["events"]
+	if !ok {
+		t.Fatal("events table not found in determinism schema")
+	}
+
+	// Check created_at has non-deterministic DEFAULT
+	createdAt, ok := table.Columns["created_at"]
+	if !ok {
+		t.Fatal("created_at column not found")
+	}
+	if !createdAt.HasDefault {
+		t.Error("created_at should have DEFAULT")
+	}
+	if createdAt.DefaultIsDeterministic {
+		t.Error("created_at DEFAULT CURRENT_TIMESTAMP should be non-deterministic")
+	}
+}
+
+func TestSchemaCache_BuildDeterminismSchema_WithTriggers(t *testing.T) {
+	cache := NewSchemaCache()
+
+	// Add table with trigger
+	cache.Update("audit_log", &TableSchema{
+		TableName: "audit_log",
+		Columns:   []string{"id", "msg"},
+		CreateSQL: `CREATE TABLE audit_log (id INTEGER, msg TEXT)`,
+		Triggers: []string{
+			`CREATE TRIGGER log_changes AFTER INSERT ON audit_log
+				BEGIN INSERT INTO backup (ts) VALUES (datetime('now')); END`,
+		},
+	})
+
+	schema := cache.BuildDeterminismSchema()
+	if schema == nil {
+		t.Fatal("BuildDeterminismSchema returned nil")
+	}
+
+	table, ok := schema.Tables["audit_log"]
+	if !ok {
+		t.Fatal("audit_log table not found")
+	}
+
+	// Table should be marked with trigger
+	if !table.HasTrigger {
+		t.Error("audit_log should have trigger marked")
+	}
+}
+
+func TestSchemaCache_BuildDeterminismSchema_Empty(t *testing.T) {
+	cache := NewSchemaCache()
+
+	schema := cache.BuildDeterminismSchema()
+	if schema == nil {
+		t.Fatal("BuildDeterminismSchema returned nil for empty cache")
+	}
+	if len(schema.Tables) != 0 {
+		t.Errorf("expected empty schema, got %d tables", len(schema.Tables))
+	}
+}
+
+func TestSchemaCache_BuildDeterminismSchema_MultipleTables(t *testing.T) {
+	cache := NewSchemaCache()
+
+	cache.Update("users", &TableSchema{
+		TableName: "users",
+		Columns:   []string{"id", "name"},
+		CreateSQL: `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT DEFAULT 'anonymous')`,
+	})
+
+	cache.Update("orders", &TableSchema{
+		TableName: "orders",
+		Columns:   []string{"id", "user_id", "created"},
+		CreateSQL: `CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, created DATETIME DEFAULT CURRENT_TIMESTAMP)`,
+	})
+
+	schema := cache.BuildDeterminismSchema()
+	if schema == nil {
+		t.Fatal("BuildDeterminismSchema returned nil")
+	}
+
+	if len(schema.Tables) != 2 {
+		t.Errorf("expected 2 tables, got %d", len(schema.Tables))
+	}
+
+	// Check users table - name has deterministic DEFAULT
+	users, ok := schema.Tables["users"]
+	if !ok {
+		t.Fatal("users table not found")
+	}
+	nameCol := users.Columns["name"]
+	if !nameCol.HasDefault || !nameCol.DefaultIsDeterministic {
+		t.Error("users.name should have deterministic DEFAULT")
+	}
+
+	// Check orders table - created has non-deterministic DEFAULT
+	orders, ok := schema.Tables["orders"]
+	if !ok {
+		t.Fatal("orders table not found")
+	}
+	createdCol := orders.Columns["created"]
+	if !createdCol.HasDefault || createdCol.DefaultIsDeterministic {
+		t.Error("orders.created should have non-deterministic DEFAULT")
+	}
+}
+
+func TestSchemaCache_BuildDeterminismSchema_NoCreateSQL(t *testing.T) {
+	cache := NewSchemaCache()
+
+	// Table without CreateSQL should be skipped silently
+	cache.Update("simple", &TableSchema{
+		TableName: "simple",
+		Columns:   []string{"id", "data"},
+		CreateSQL: "", // No CREATE SQL
+	})
+
+	schema := cache.BuildDeterminismSchema()
+	if schema == nil {
+		t.Fatal("BuildDeterminismSchema returned nil")
+	}
+
+	// Table should not be in schema since we couldn't parse it
+	if len(schema.Tables) != 0 {
+		t.Errorf("expected 0 tables (no CreateSQL), got %d", len(schema.Tables))
+	}
+}
+
+func TestPipeline_DeterminismWithSchema(t *testing.T) {
+	// Create a determinism schema with a table that has non-det DEFAULT
+	schema := determinism.NewSchema()
+	schema.AddTable(`CREATE TABLE events (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`)
+
+	// Create schema provider
+	schemaProvider := func() *determinism.Schema {
+		return schema
+	}
+
+	// This test would require creating a Pipeline with the schemaProvider
+	// and verifying INSERT statements are marked non-deterministic when
+	// missing the created_at column.
+	// For now, we test the schema provider function works:
+	result := schemaProvider()
+	if result == nil {
+		t.Fatal("schemaProvider returned nil")
+	}
+
+	// Verify the schema has the expected table
+	if _, ok := result.Tables["events"]; !ok {
+		t.Fatal("events table not found in schema")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/nats-io/nats.go v1.47.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/puzpuzpuz/xsync/v3 v3.5.1
+	github.com/rqlite/sql v0.0.0-20241111133259-a4122fabb196
 	github.com/rs/zerolog v1.31.0
 	github.com/segmentio/kafka-go v0.4.49
 	github.com/soheilhy/cmux v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d h1:QQP1nE4qh5aHTGvI1LgOFxZYVxYoGeMfbNHikogPyoA=
 github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -132,6 +134,8 @@ github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPK
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rqlite/sql v0.0.0-20241111133259-a4122fabb196 h1:SjRKMwKLTEE3STO6unJlz4VlMjMv5NZgIdI9HikBeAc=
+github.com/rqlite/sql v0.0.0-20241111133259-a4122fabb196/go.mod h1:ib9zVtNgRKiGuoMyUqqL5aNpk+r+++YlyiVIkclVqPg=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/protocol/determinism/detector.go
+++ b/protocol/determinism/detector.go
@@ -1,0 +1,353 @@
+// Package determinism provides detection of non-deterministic SQL expressions.
+// This module determines if a DML statement can be safely replicated via statement-based
+// replication, or if it requires CDC (row-based) replication to avoid data divergence.
+package determinism
+
+import (
+	"strings"
+
+	"github.com/rqlite/sql"
+)
+
+// deterministicFunctions contains functions known to be pure/deterministic.
+// Unknown functions default to non-deterministic (fail-safe).
+var deterministicFunctions = map[string]bool{
+	// Math functions
+	"abs":      true,
+	"sign":     true,
+	"round":    true,
+	"min":      true,
+	"max":      true,
+	"least":    true,
+	"greatest": true,
+
+	// SQLite core functions
+	"coalesce":     true,
+	"ifnull":       true,
+	"nullif":       true,
+	"iif":          true,
+	"typeof":       true,
+	"zeroblob":     true,
+	"likelihood":   true,
+	"likely":       true,
+	"unlikely":     true,
+	"glob":         true,
+	"like":         true,
+	"instr":        true,
+	"unicode":      true,
+	"char":         true,
+	"printf":       true,
+	"format":       true,
+	"hex":          true,
+	"unhex":        true,
+	"quote":        true,
+	"substr":       true,
+	"substring":    true,
+	"replace":      true,
+	"trim":         true,
+	"ltrim":        true,
+	"rtrim":        true,
+	"length":       true,
+	"lower":        true,
+	"upper":        true,
+	"soundex":      true,
+	"group_concat": true,
+
+	// JSON functions (deterministic with same input)
+	"json":              true,
+	"json_array":        true,
+	"json_object":       true,
+	"json_extract":      true,
+	"json_insert":       true,
+	"json_remove":       true,
+	"json_replace":      true,
+	"json_set":          true,
+	"json_type":         true,
+	"json_valid":        true,
+	"json_quote":        true,
+	"json_group_array":  true,
+	"json_group_object": true,
+
+	// Aggregate functions (deterministic for same input set)
+	"count": true,
+	"sum":   true,
+	"avg":   true,
+	"total": true,
+
+	// Cast is deterministic
+	"cast": true,
+}
+
+// nonDeterministicFunctions contains functions that are always non-deterministic.
+var nonDeterministicFunctions = map[string]bool{
+	"random":            true,
+	"randomblob":        true,
+	"changes":           true,
+	"last_insert_rowid": true,
+	"total_changes":     true,
+}
+
+// nonDeterministicIdents are SQLite keywords that return current time.
+// These are parsed as identifiers, not function calls.
+var nonDeterministicIdents = map[string]bool{
+	"current_date":      true,
+	"current_time":      true,
+	"current_timestamp": true,
+}
+
+// timeFunctionsWithNow are functions that are non-deterministic only when called with 'now'.
+var timeFunctionsWithNow = map[string]bool{
+	"datetime":  true,
+	"date":      true,
+	"time":      true,
+	"julianday": true,
+	"strftime":  true,
+	"unixepoch": true,
+	"timediff":  true,
+}
+
+// Result holds the determinism check result
+type Result struct {
+	IsDeterministic bool
+	Reason          string
+	NonDetFunctions []string // List of non-deterministic function calls found
+}
+
+// IsDeterministicFunction checks if a function name is in the deterministic whitelist.
+// Case-insensitive. Returns false for unknown functions (fail-safe).
+func IsDeterministicFunction(name string) bool {
+	lower := strings.ToLower(name)
+	if nonDeterministicFunctions[lower] {
+		return false
+	}
+	if timeFunctionsWithNow[lower] {
+		return false // These need argument checking
+	}
+	return deterministicFunctions[lower]
+}
+
+// CheckSQL parses SQLite SQL and checks for non-deterministic expressions.
+// Returns a Result with determinism status and details.
+func CheckSQL(sqlStr string) Result {
+	parser := sql.NewParser(strings.NewReader(sqlStr))
+	stmt, err := parser.ParseStatement()
+	if err != nil {
+		// If we can't parse, assume non-deterministic (fail-safe)
+		return Result{
+			IsDeterministic: false,
+			Reason:          "parse error: " + err.Error(),
+		}
+	}
+	return CheckStatement(stmt)
+}
+
+// CheckStatement checks a parsed SQLite statement for non-deterministic expressions.
+func CheckStatement(stmt sql.Statement) Result {
+	checker := &deterministicChecker{}
+	sql.Walk(checker, stmt)
+
+	if len(checker.nonDetFuncs) > 0 {
+		return Result{
+			IsDeterministic: false,
+			Reason:          checker.reason,
+			NonDetFunctions: checker.nonDetFuncs,
+		}
+	}
+
+	if checker.hasSubquery {
+		return Result{
+			IsDeterministic: false,
+			Reason:          "contains subquery",
+		}
+	}
+
+	if checker.hasColumnInSet {
+		return Result{
+			IsDeterministic: false,
+			Reason:          "column reference in SET clause",
+		}
+	}
+
+	if checker.hasLimitNoOrderBy {
+		return Result{
+			IsDeterministic: false,
+			Reason:          "DELETE with LIMIT but no ORDER BY",
+		}
+	}
+
+	return Result{IsDeterministic: true}
+}
+
+// deterministicChecker implements sql.Visitor to walk the AST
+type deterministicChecker struct {
+	nonDetFuncs       []string
+	reason            string
+	hasSubquery       bool
+	hasColumnInSet    bool
+	hasLimitNoOrderBy bool
+	inUpdateSet       bool // Track if we're inside UPDATE SET clause
+}
+
+func (c *deterministicChecker) Visit(node sql.Node) (sql.Visitor, sql.Node, error) {
+	switch n := node.(type) {
+	case *sql.Call:
+		c.checkFunctionCall(n)
+	case *sql.Ident:
+		// Check for non-deterministic identifiers like CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP
+		c.checkIdent(n)
+	case *sql.SelectStatement:
+		// Subquery detection - if we see a SELECT inside another statement
+		c.hasSubquery = true
+	case *sql.ParenExpr:
+		// Check if ParenExpr contains a SELECT (subquery)
+		if _, ok := n.X.(sql.SelectExpr); ok {
+			c.hasSubquery = true
+		}
+	case *sql.ExprList:
+		// Check if ExprList contains a SELECT (for IN subquery)
+		for _, expr := range n.Exprs {
+			if _, ok := expr.(sql.SelectExpr); ok {
+				c.hasSubquery = true
+				break
+			}
+		}
+	case *sql.UpdateStatement:
+		// Check SET clause for column references
+		for _, assignment := range n.Assignments {
+			if c.exprHasColumnRef(assignment.Expr) {
+				c.hasColumnInSet = true
+				break
+			}
+		}
+	case *sql.DeleteStatement:
+		// DELETE with LIMIT but no ORDER BY is non-deterministic
+		// (which rows get deleted is implementation-defined)
+		if n.LimitExpr != nil && len(n.OrderingTerms) == 0 {
+			c.hasLimitNoOrderBy = true
+		}
+	}
+	return c, node, nil
+}
+
+func (c *deterministicChecker) VisitEnd(node sql.Node) (sql.Node, error) {
+	return node, nil
+}
+
+func (c *deterministicChecker) checkIdent(ident *sql.Ident) {
+	name := strings.ToLower(ident.Name)
+	if nonDeterministicIdents[name] {
+		c.nonDetFuncs = append(c.nonDetFuncs, ident.Name)
+		if c.reason == "" {
+			c.reason = "non-deterministic identifier: " + name
+		}
+	}
+}
+
+func (c *deterministicChecker) checkFunctionCall(call *sql.Call) {
+	name := strings.ToLower(call.Name.Name)
+
+	// Check blacklist
+	if nonDeterministicFunctions[name] {
+		c.nonDetFuncs = append(c.nonDetFuncs, call.String())
+		if c.reason == "" {
+			c.reason = "non-deterministic function: " + name
+		}
+		return
+	}
+
+	// Check time functions with 'now' argument
+	if timeFunctionsWithNow[name] {
+		if c.hasNowArgument(call) {
+			c.nonDetFuncs = append(c.nonDetFuncs, call.String())
+			if c.reason == "" {
+				c.reason = name + " with 'now' argument"
+			}
+		}
+		return
+	}
+
+	// Check whitelist - unknown functions are non-deterministic
+	if !deterministicFunctions[name] {
+		c.nonDetFuncs = append(c.nonDetFuncs, call.String())
+		if c.reason == "" {
+			c.reason = "unknown function: " + name
+		}
+	}
+}
+
+func (c *deterministicChecker) hasNowArgument(call *sql.Call) bool {
+	name := strings.ToLower(call.Name.Name)
+
+	// strftime(format, timestring, ...) - format is required, timestring defaults to 'now'
+	if name == "strftime" {
+		if len(call.Args) <= 1 {
+			// Only format provided, timestring defaults to 'now'
+			return true
+		}
+		// Check if second arg (timestring) is 'now'
+		if len(call.Args) >= 2 {
+			if lit, ok := call.Args[1].(*sql.StringLit); ok {
+				if strings.ToLower(lit.Value) == "now" {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Other time functions: datetime/date/time/julianday/unixepoch(timestring, ...)
+	if len(call.Args) == 0 {
+		// No args = defaults to 'now'
+		return true
+	}
+
+	// Check first argument for 'now'
+	if lit, ok := call.Args[0].(*sql.StringLit); ok {
+		if strings.ToLower(lit.Value) == "now" {
+			return true
+		}
+	}
+	return false
+}
+
+// columnRefChecker walks an expression to find column references
+type columnRefChecker struct {
+	hasCol *bool
+}
+
+func (v *columnRefChecker) Visit(node sql.Node) (sql.Visitor, sql.Node, error) {
+	switch n := node.(type) {
+	case *sql.Call:
+		// Walk arguments only, skip the function name (which is also an Ident)
+		for _, arg := range n.Args {
+			sql.Walk(&columnRefChecker{hasCol: v.hasCol}, arg)
+		}
+		// Return nil to stop recursion into Call's children (Name field)
+		return nil, node, nil
+	case *sql.Ident:
+		*v.hasCol = true
+	case *sql.QualifiedRef:
+		*v.hasCol = true
+	}
+	return v, node, nil
+}
+
+func (v *columnRefChecker) VisitEnd(node sql.Node) (sql.Node, error) {
+	return node, nil
+}
+
+func (c *deterministicChecker) exprHasColumnRef(expr sql.Expr) bool {
+	hasCol := false
+	sql.Walk(&columnRefChecker{hasCol: &hasCol}, expr)
+	return hasCol
+}
+
+// IsDeterministic is a convenience function that returns just the boolean result.
+func IsDeterministic(sqlStr string) bool {
+	return CheckSQL(sqlStr).IsDeterministic
+}
+
+// IsDeterministicStatement checks a parsed statement.
+func IsDeterministicStatement(stmt sql.Statement) bool {
+	return CheckStatement(stmt).IsDeterministic
+}

--- a/protocol/determinism/detector_test.go
+++ b/protocol/determinism/detector_test.go
@@ -1,0 +1,945 @@
+package determinism
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCheckSQL_DeterministicStatements tests that deterministic statements are correctly identified
+func TestCheckSQL_DeterministicStatements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		// INSERT with literals
+		{"INSERT with literals", "INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com')"},
+		{"INSERT with multiple rows", "INSERT INTO users (id, name) VALUES (1, 'Alice'), (2, 'Bob')"},
+		{"INSERT with NULL", "INSERT INTO users (id, name, email) VALUES (1, 'Alice', NULL)"},
+		{"INSERT with numbers", "INSERT INTO products (id, price, qty) VALUES (1, 19.99, 100)"},
+
+		// INSERT with deterministic functions
+		{"INSERT with upper()", "INSERT INTO users (id, name) VALUES (1, upper('alice'))"},
+		{"INSERT with lower()", "INSERT INTO users (id, name) VALUES (1, lower('ALICE'))"},
+		{"INSERT with coalesce()", "INSERT INTO users (id, name) VALUES (1, coalesce('primary', 'default'))"},
+		{"INSERT with ifnull()", "INSERT INTO users (id, name) VALUES (1, ifnull('value', 'default'))"},
+		{"INSERT with abs()", "INSERT INTO numbers (id, value) VALUES (1, abs(-42))"},
+		{"INSERT with length()", "INSERT INTO stats (id, len) VALUES (1, length('hello'))"},
+		{"INSERT with substr()", "INSERT INTO users (id, initial) VALUES (1, substr('Alice', 1, 1))"},
+		// Note: replace() function not tested - rqlite/sql parser treats REPLACE as keyword
+		{"INSERT with trim()", "INSERT INTO users (id, name) VALUES (1, trim('  Alice  '))"},
+		{"INSERT with round()", "INSERT INTO prices (id, value) VALUES (1, round(19.999, 2))"},
+		{"INSERT with hex()", "INSERT INTO data (id, hex_val) VALUES (1, hex('hello'))"},
+		{"INSERT with nested deterministic", "INSERT INTO users (id, name) VALUES (1, upper(trim(lower('  ALICE  '))))"},
+
+		// datetime/date/time with fixed values (NOT 'now')
+		{"datetime with fixed string", "INSERT INTO events (id, created) VALUES (1, datetime('2024-01-01'))"},
+		{"datetime with fixed and modifier", "INSERT INTO events (id, created) VALUES (1, datetime('2024-01-01', '+1 day'))"},
+		{"date with fixed string", "INSERT INTO events (id, day) VALUES (1, date('2024-01-01'))"},
+		{"time with fixed string", "INSERT INTO events (id, t) VALUES (1, time('12:30:00'))"},
+		{"strftime with fixed", "INSERT INTO events (id, yr) VALUES (1, strftime('%Y', '2024-01-01'))"},
+
+		// UPDATE with literals in SET
+		{"UPDATE SET literal", "UPDATE users SET name = 'Bob' WHERE id = 1"},
+		{"UPDATE SET multiple literals", "UPDATE users SET name = 'Bob', email = 'bob@example.com' WHERE id = 1"},
+		{"UPDATE SET NULL", "UPDATE users SET email = NULL WHERE id = 1"},
+		{"UPDATE SET with deterministic function", "UPDATE users SET name = upper('alice') WHERE id = 1"},
+
+		// DELETE (deterministic as long as WHERE doesn't use non-det functions)
+		{"DELETE with literal WHERE", "DELETE FROM users WHERE id = 1"},
+		{"DELETE with string literal WHERE", "DELETE FROM users WHERE status = 'inactive'"},
+		{"DELETE with IN literal list", "DELETE FROM users WHERE id IN (1, 2, 3)"},
+		{"DELETE with deterministic function in WHERE", "DELETE FROM users WHERE name = upper('alice')"},
+		{"DELETE LIMIT with ORDER BY", "DELETE FROM users ORDER BY id LIMIT 10"},
+
+		// Arithmetic with literals
+		{"arithmetic with literals", "INSERT INTO data (id, val) VALUES (1, 10 + 20 * 3)"},
+
+		// CASE with literals
+		{"CASE with literal conditions", "INSERT INTO data (id, category) VALUES (1, CASE WHEN 1 = 1 THEN 'A' ELSE 'B' END)"},
+
+		// JSON functions
+		{"json_extract", "INSERT INTO data (id, val) VALUES (1, json_extract('{\"a\":1}', '$.a'))"},
+		{"json_object", "INSERT INTO data (id, val) VALUES (1, json_object('a', 1, 'b', 2))"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if !result.IsDeterministic {
+				t.Errorf("expected deterministic, got non-deterministic: reason=%q, funcs=%v\nSQL: %s",
+					result.Reason, result.NonDetFunctions, tt.sql)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_NonDeterministicStatements tests that non-deterministic statements are correctly identified
+func TestCheckSQL_NonDeterministicStatements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sql        string
+		wantReason string // substring expected in reason
+	}{
+		// random() and randomblob()
+		{"INSERT with random()", "INSERT INTO users (id, token) VALUES (1, random())", "random"},
+		{"INSERT with randomblob()", "INSERT INTO data (id, blob) VALUES (1, randomblob(16))", "randomblob"},
+
+		// datetime/date/time with 'now'
+		{"datetime('now')", "INSERT INTO events (id, created) VALUES (1, datetime('now'))", "datetime"},
+		{"datetime('now', 'localtime')", "INSERT INTO events (id, created) VALUES (1, datetime('now', 'localtime'))", "datetime"},
+		{"date('now')", "INSERT INTO events (id, day) VALUES (1, date('now'))", "date"},
+		{"time('now')", "INSERT INTO events (id, t) VALUES (1, time('now'))", "time"},
+		{"strftime with 'now'", "INSERT INTO events (id, yr) VALUES (1, strftime('%Y', 'now'))", "strftime"},
+		{"julianday('now')", "INSERT INTO events (id, jd) VALUES (1, julianday('now'))", "julianday"},
+
+		// datetime() with no args (equivalent to 'now')
+		{"datetime() no args", "INSERT INTO events (id, created) VALUES (1, datetime())", "datetime"},
+
+		// Nested with non-deterministic inner function
+		{"abs(random())", "INSERT INTO data (id, val) VALUES (1, abs(random()))", "random"},
+		{"upper with random", "INSERT INTO data (id, val) VALUES (1, upper(hex(randomblob(4))))", "randomblob"},
+		{"coalesce with datetime('now')", "INSERT INTO data (id, val) VALUES (1, coalesce(NULL, datetime('now')))", "datetime"},
+
+		// UPDATE SET with column reference (non-deterministic for statement-based replication)
+		{"UPDATE SET self-reference", "UPDATE products SET stock = stock - 1 WHERE id = 100", "column reference"},
+		{"UPDATE SET column reference", "UPDATE users SET backup_email = email WHERE id = 1", "column reference"},
+		{"UPDATE SET arithmetic on column", "UPDATE counters SET value = value + 1 WHERE id = 1", "column reference"},
+		{"UPDATE SET function on column", "UPDATE users SET name = upper(name) WHERE id = 1", "column reference"},
+		{"UPDATE SET coalesce with column", "UPDATE users SET name = coalesce(nickname, name, 'Anonymous') WHERE id = 1", "column reference"},
+
+		// UPDATE/DELETE with non-deterministic in WHERE
+		{"UPDATE with random() in SET", "UPDATE users SET token = random() WHERE id = 1", "random"},
+		{"DELETE with random() in WHERE", "DELETE FROM users WHERE random() < 100", "random"},
+
+		// Subqueries
+		{"INSERT with scalar subquery", "INSERT INTO summary (id, total) SELECT 1, sum(amount) FROM orders", "subquery"},
+		{"UPDATE with subquery in SET", "UPDATE users SET total = (SELECT sum(amount) FROM orders WHERE user_id = 1) WHERE id = 1", "subquery"},
+		{"DELETE with subquery in WHERE", "DELETE FROM users WHERE id IN (SELECT user_id FROM banned_users)", "subquery"},
+
+		// Unknown functions (fail-safe)
+		{"unknown function", "INSERT INTO data (id, val) VALUES (1, custom_func('arg'))", "unknown function"},
+		{"UDF-like function", "INSERT INTO data (id, val) VALUES (1, my_udf(123))", "unknown function"},
+
+		// CASE with non-deterministic
+		{"CASE with random()", "INSERT INTO data (id, status) VALUES (1, CASE WHEN random() > 0 THEN 'a' ELSE 'b' END)", "random"},
+
+		// changes() and last_insert_rowid()
+		{"changes()", "INSERT INTO log (id, changed) VALUES (1, changes())", "changes"},
+		{"last_insert_rowid()", "INSERT INTO log (id, last_id) VALUES (1, last_insert_rowid())", "last_insert_rowid"},
+
+		// CURRENT_DATE/TIME/TIMESTAMP (parsed as identifiers, not functions)
+		{"CURRENT_DATE", "INSERT INTO t (d) VALUES (CURRENT_DATE)", "non-deterministic identifier"},
+		{"CURRENT_TIME", "INSERT INTO t (d) VALUES (CURRENT_TIME)", "non-deterministic identifier"},
+		{"CURRENT_TIMESTAMP", "INSERT INTO t (d) VALUES (CURRENT_TIMESTAMP)", "non-deterministic identifier"},
+
+		// strftime with no time arg (defaults to 'now')
+		{"strftime no time arg", "INSERT INTO t (ts) VALUES (strftime('%s'))", "strftime"},
+
+		// INSERT ... SELECT (contains SELECT = subquery)
+		{"INSERT SELECT", "INSERT INTO archive SELECT * FROM users", "subquery"},
+		{"INSERT columns SELECT", "INSERT INTO t (a, b) SELECT x, y FROM t2", "subquery"},
+
+		// rowid/oid/_rowid_ in UPDATE SET
+		{"rowid in SET", "UPDATE t SET x = rowid WHERE id = 1", "column reference"},
+		{"_rowid_ in SET", "UPDATE t SET x = _rowid_ WHERE id = 1", "column reference"},
+		{"oid in SET", "UPDATE t SET x = oid WHERE id = 1", "column reference"},
+
+		// DELETE with LIMIT but no ORDER BY (rows affected are undefined)
+		{"DELETE LIMIT no ORDER BY", "DELETE FROM t LIMIT 1", "LIMIT but no ORDER BY"},
+		{"DELETE WHERE LIMIT no ORDER BY", "DELETE FROM t WHERE x = 1 LIMIT 5", "LIMIT but no ORDER BY"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic, got deterministic\nSQL: %s", tt.sql)
+				return
+			}
+			if tt.wantReason != "" && result.Reason == "" {
+				t.Errorf("expected reason containing %q, got empty", tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestIsDeterministicFunction tests the function whitelist
+func TestIsDeterministicFunction(t *testing.T) {
+	t.Parallel()
+
+	deterministic := []string{
+		"abs", "round", "min", "max", "coalesce", "ifnull", "nullif",
+		"length", "lower", "upper", "trim", "ltrim", "rtrim",
+		"substr", "replace", "instr", "hex", "quote", "printf",
+		"json_extract", "json_object", "json_array",
+		"count", "sum", "avg", "total",
+	}
+
+	for _, fn := range deterministic {
+		t.Run(fn, func(t *testing.T) {
+			if !IsDeterministicFunction(fn) {
+				t.Errorf("expected %q to be deterministic", fn)
+			}
+			// Test case insensitivity
+			if !IsDeterministicFunction(strings.ToUpper(fn)) {
+				t.Errorf("expected %q (uppercase) to be deterministic", strings.ToUpper(fn))
+			}
+		})
+	}
+
+	nonDeterministic := []string{
+		"random", "randomblob", "changes", "last_insert_rowid", "total_changes",
+		"datetime", "date", "time", "julianday", "strftime", // These need 'now' check
+	}
+
+	for _, fn := range nonDeterministic {
+		t.Run(fn+"_nondet", func(t *testing.T) {
+			if IsDeterministicFunction(fn) {
+				t.Errorf("expected %q to be non-deterministic", fn)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_EdgeCases tests edge cases
+func TestCheckSQL_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantDet bool
+	}{
+		// Empty string values
+		{"INSERT with empty string", "INSERT INTO data (id, val) VALUES (1, '')", true},
+		{"UPDATE SET empty string", "UPDATE data SET val = '' WHERE id = 1", true},
+
+		// Zero values
+		{"INSERT with zero", "INSERT INTO data (id, val) VALUES (1, 0)", true},
+		{"INSERT with negative", "INSERT INTO data (id, val) VALUES (1, -100)", true},
+
+		// Column in WHERE only (deterministic - WHERE doesn't affect result values)
+		{"UPDATE with column in WHERE", "UPDATE users SET status = 'verified' WHERE email LIKE '%@company.com'", true},
+		{"DELETE with column comparison", "DELETE FROM users WHERE email = backup_email", true},
+
+		// Multiple statements (parser handles first one)
+		{"simple INSERT", "INSERT INTO t (id) VALUES (1)", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic != tt.wantDet {
+				t.Errorf("IsDeterministic = %v, want %v, reason: %s\nSQL: %s",
+					result.IsDeterministic, tt.wantDet, result.Reason, tt.sql)
+			}
+		})
+	}
+}
+
+// TestIsDeterministic tests the convenience function
+func TestIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	if !IsDeterministic("INSERT INTO t (id, name) VALUES (1, 'test')") {
+		t.Error("expected deterministic for simple INSERT")
+	}
+
+	if IsDeterministic("INSERT INTO t (id, ts) VALUES (1, datetime('now'))") {
+		t.Error("expected non-deterministic for datetime('now')")
+	}
+
+	if IsDeterministic("UPDATE t SET val = val + 1 WHERE id = 1") {
+		t.Error("expected non-deterministic for column self-reference")
+	}
+}
+
+// TestCheckSQL_NonDeterministicFunctions tests all known non-deterministic functions
+func TestCheckSQL_NonDeterministicFunctions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sql        string
+		wantReason string
+	}{
+		// random() variants
+		{"random() in INSERT", "INSERT INTO t (id, v) VALUES (1, random())", "random"},
+		{"random() in UPDATE SET", "UPDATE t SET v = random() WHERE id = 1", "random"},
+		{"random() in WHERE", "DELETE FROM t WHERE v = random()", "random"},
+		{"random() case insensitive", "INSERT INTO t (id, v) VALUES (1, RANDOM())", "random"},
+
+		// randomblob()
+		{"randomblob(16)", "INSERT INTO t (id, blob) VALUES (1, randomblob(16))", "randomblob"},
+		{"randomblob(32)", "INSERT INTO t (id, blob) VALUES (1, randomblob(32))", "randomblob"},
+		{"randomblob case insensitive", "INSERT INTO t (id, blob) VALUES (1, RANDOMBLOB(8))", "randomblob"},
+
+		// changes()
+		{"changes()", "INSERT INTO log (id, n) VALUES (1, changes())", "changes"},
+		{"changes() in UPDATE", "UPDATE t SET v = changes() WHERE id = 1", "changes"},
+		{"CHANGES() uppercase", "INSERT INTO log (n) VALUES (CHANGES())", "changes"},
+
+		// last_insert_rowid()
+		{"last_insert_rowid()", "INSERT INTO t (id, ref) VALUES (1, last_insert_rowid())", "last_insert_rowid"},
+		{"LAST_INSERT_ROWID uppercase", "INSERT INTO t (ref) VALUES (LAST_INSERT_ROWID())", "last_insert_rowid"},
+
+		// total_changes()
+		{"total_changes()", "INSERT INTO stats (id, total) VALUES (1, total_changes())", "total_changes"},
+		{"TOTAL_CHANGES uppercase", "INSERT INTO stats (total) VALUES (TOTAL_CHANGES())", "total_changes"},
+		{"total_changes() in UPDATE", "UPDATE stats SET total = total_changes() WHERE id = 1", "total_changes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic, got deterministic\nSQL: %s", tt.sql)
+				return
+			}
+			if !strings.Contains(strings.ToLower(result.Reason), strings.ToLower(tt.wantReason)) {
+				t.Errorf("reason %q should contain %q", result.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_TimeFunctionsWithNow tests time functions with 'now' argument variations
+func TestCheckSQL_TimeFunctionsWithNow(t *testing.T) {
+	t.Parallel()
+
+	nonDetTests := []struct {
+		name string
+		sql  string
+	}{
+		// datetime() variants
+		{"datetime('now')", "INSERT INTO t (ts) VALUES (datetime('now'))"},
+		{"datetime('NOW') uppercase", "INSERT INTO t (ts) VALUES (datetime('NOW'))"},
+		{"datetime('now', 'localtime')", "INSERT INTO t (ts) VALUES (datetime('now', 'localtime'))"},
+		{"datetime('now', '+1 day')", "INSERT INTO t (ts) VALUES (datetime('now', '+1 day'))"},
+		{"datetime() no args", "INSERT INTO t (ts) VALUES (datetime())"},
+		{"DATETIME('now')", "INSERT INTO t (ts) VALUES (DATETIME('now'))"},
+
+		// date() variants
+		{"date('now')", "INSERT INTO t (d) VALUES (date('now'))"},
+		{"date('NOW')", "INSERT INTO t (d) VALUES (date('NOW'))"},
+		{"date('now', 'start of month')", "INSERT INTO t (d) VALUES (date('now', 'start of month'))"},
+		{"date() no args", "INSERT INTO t (d) VALUES (date())"},
+		{"DATE('now')", "INSERT INTO t (d) VALUES (DATE('now'))"},
+
+		// time() variants
+		{"time('now')", "INSERT INTO t (tm) VALUES (time('now'))"},
+		{"time('NOW')", "INSERT INTO t (tm) VALUES (time('NOW'))"},
+		{"time('now', '+2 hours')", "INSERT INTO t (tm) VALUES (time('now', '+2 hours'))"},
+		{"time() no args", "INSERT INTO t (tm) VALUES (time())"},
+		{"TIME('now')", "INSERT INTO t (tm) VALUES (TIME('now'))"},
+
+		// julianday() variants
+		{"julianday('now')", "INSERT INTO t (jd) VALUES (julianday('now'))"},
+		{"julianday('NOW')", "INSERT INTO t (jd) VALUES (julianday('NOW'))"},
+		{"julianday() no args", "INSERT INTO t (jd) VALUES (julianday())"},
+		{"JULIANDAY('now')", "INSERT INTO t (jd) VALUES (JULIANDAY('now'))"},
+
+		// strftime() variants
+		{"strftime('%Y', 'now')", "INSERT INTO t (yr) VALUES (strftime('%Y', 'now'))"},
+		{"strftime('%s', 'now')", "INSERT INTO t (ts) VALUES (strftime('%s', 'now'))"},
+		{"strftime('%Y-%m-%d', 'now')", "INSERT INTO t (d) VALUES (strftime('%Y-%m-%d', 'now'))"},
+		{"strftime('%s') single arg", "INSERT INTO t (ts) VALUES (strftime('%s'))"},
+		{"strftime('%Y') single arg", "INSERT INTO t (yr) VALUES (strftime('%Y'))"},
+		{"STRFTIME('%s', 'now')", "INSERT INTO t (ts) VALUES (STRFTIME('%s', 'now'))"},
+
+		// unixepoch() variants
+		{"unixepoch('now')", "INSERT INTO t (ts) VALUES (unixepoch('now'))"},
+		{"unixepoch() no args", "INSERT INTO t (ts) VALUES (unixepoch())"},
+		{"UNIXEPOCH('now')", "INSERT INTO t (ts) VALUES (UNIXEPOCH('now'))"},
+
+		// timediff() variants
+		{"timediff('now', '2024-01-01')", "INSERT INTO t (diff) VALUES (timediff('now', '2024-01-01'))"},
+		{"timediff() no args", "INSERT INTO t (diff) VALUES (timediff())"},
+	}
+
+	for _, tt := range nonDetTests {
+		t.Run(tt.name+"_nondet", func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic\nSQL: %s", tt.sql)
+			}
+		})
+	}
+
+	// Deterministic time function calls (fixed timestamps)
+	detTests := []struct {
+		name string
+		sql  string
+	}{
+		{"datetime('2024-01-01')", "INSERT INTO t (ts) VALUES (datetime('2024-01-01'))"},
+		{"datetime('2024-01-01', '+1 day')", "INSERT INTO t (ts) VALUES (datetime('2024-01-01', '+1 day'))"},
+		{"date('2024-01-01')", "INSERT INTO t (d) VALUES (date('2024-01-01'))"},
+		{"date('2024-01-01', 'start of month')", "INSERT INTO t (d) VALUES (date('2024-01-01', 'start of month'))"},
+		{"time('12:30:00')", "INSERT INTO t (tm) VALUES (time('12:30:00'))"},
+		{"time('12:30:00', '+1 hour')", "INSERT INTO t (tm) VALUES (time('12:30:00', '+1 hour'))"},
+		{"julianday('2024-01-01')", "INSERT INTO t (jd) VALUES (julianday('2024-01-01'))"},
+		{"strftime('%Y', '2024-01-01')", "INSERT INTO t (yr) VALUES (strftime('%Y', '2024-01-01'))"},
+		{"strftime('%s', '2024-01-01 12:00:00')", "INSERT INTO t (ts) VALUES (strftime('%s', '2024-01-01 12:00:00'))"},
+		{"unixepoch('2024-01-01')", "INSERT INTO t (ts) VALUES (unixepoch('2024-01-01'))"},
+		{"timediff('2024-01-01', '2023-01-01')", "INSERT INTO t (diff) VALUES (timediff('2024-01-01', '2023-01-01'))"},
+	}
+
+	for _, tt := range detTests {
+		t.Run(tt.name+"_det", func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if !result.IsDeterministic {
+				t.Errorf("expected deterministic, reason=%s\nSQL: %s", result.Reason, tt.sql)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_CurrentTimeIdentifiers tests CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP
+func TestCheckSQL_CurrentTimeIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		// Basic usage
+		{"CURRENT_DATE", "INSERT INTO t (d) VALUES (CURRENT_DATE)"},
+		{"CURRENT_TIME", "INSERT INTO t (tm) VALUES (CURRENT_TIME)"},
+		{"CURRENT_TIMESTAMP", "INSERT INTO t (ts) VALUES (CURRENT_TIMESTAMP)"},
+
+		// Mixed case
+		{"current_date lowercase", "INSERT INTO t (d) VALUES (current_date)"},
+		{"current_time lowercase", "INSERT INTO t (tm) VALUES (current_time)"},
+		{"current_timestamp lowercase", "INSERT INTO t (ts) VALUES (current_timestamp)"},
+		{"Current_Date mixedcase", "INSERT INTO t (d) VALUES (Current_Date)"},
+
+		// In expressions
+		{"CURRENT_DATE in expression", "INSERT INTO t (d, label) VALUES (CURRENT_DATE, 'today')"},
+		{"CURRENT_TIMESTAMP in UPDATE", "UPDATE t SET ts = CURRENT_TIMESTAMP WHERE id = 1"},
+		{"CURRENT_TIME in multiple columns", "INSERT INTO t (tm1, tm2) VALUES (CURRENT_TIME, CURRENT_TIME)"},
+
+		// In WHERE clause
+		{"CURRENT_DATE in WHERE", "DELETE FROM t WHERE d < CURRENT_DATE"},
+		{"CURRENT_TIMESTAMP in WHERE", "UPDATE t SET status = 'old' WHERE ts < CURRENT_TIMESTAMP"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic\nSQL: %s", tt.sql)
+			}
+			if result.Reason == "" {
+				t.Error("expected non-empty reason")
+			}
+		})
+	}
+}
+
+// TestCheckSQL_ColumnReferencesInUpdateSet tests column references in UPDATE SET clauses
+func TestCheckSQL_ColumnReferencesInUpdateSet(t *testing.T) {
+	t.Parallel()
+
+	nonDetTests := []struct {
+		name string
+		sql  string
+	}{
+		// Self-reference arithmetic
+		{"x = x + 1", "UPDATE t SET x = x + 1 WHERE id = 1"},
+		{"x = x - 1", "UPDATE t SET x = x - 1 WHERE id = 1"},
+		{"x = x * 2", "UPDATE t SET x = x * 2 WHERE id = 1"},
+		{"x = x / 2", "UPDATE t SET x = x / 2 WHERE id = 1"},
+		{"x = x || 'suffix'", "UPDATE t SET x = x || 'suffix' WHERE id = 1"},
+
+		// Cross-column reference
+		{"x = y", "UPDATE t SET x = y WHERE id = 1"},
+		{"x = y + z", "UPDATE t SET x = y + z WHERE id = 1"},
+		{"email_backup = email", "UPDATE users SET email_backup = email WHERE id = 1"},
+
+		// Column in function
+		{"x = upper(name)", "UPDATE t SET x = upper(name) WHERE id = 1"},
+		{"x = lower(name)", "UPDATE t SET x = lower(name) WHERE id = 1"},
+		{"x = length(data)", "UPDATE t SET x = length(data) WHERE id = 1"},
+		{"x = coalesce(a, b, c)", "UPDATE t SET x = coalesce(a, b, c) WHERE id = 1"},
+		{"x = abs(value)", "UPDATE t SET x = abs(value) WHERE id = 1"},
+		{"x = substr(name, 1, 3)", "UPDATE t SET x = substr(name, 1, 3) WHERE id = 1"},
+
+		// rowid variants
+		{"x = rowid", "UPDATE t SET x = rowid WHERE id = 1"},
+		{"x = _rowid_", "UPDATE t SET x = _rowid_ WHERE id = 1"},
+		{"x = oid", "UPDATE t SET x = oid WHERE id = 1"},
+		{"x = ROWID", "UPDATE t SET x = ROWID WHERE id = 1"},
+
+		// Qualified column reference
+		{"x = t.y", "UPDATE t SET x = t.y WHERE id = 1"},
+
+		// Multiple assignments with column ref
+		{"a = b, c = d", "UPDATE t SET a = b, c = d WHERE id = 1"},
+		{"counter = counter + 1, updated = 1", "UPDATE t SET counter = counter + 1, updated = 1 WHERE id = 1"},
+
+		// Nested column references
+		{"x = upper(lower(name))", "UPDATE t SET x = upper(lower(name)) WHERE id = 1"},
+		{"x = coalesce(nullif(a, ''), b)", "UPDATE t SET x = coalesce(nullif(a, ''), b) WHERE id = 1"},
+	}
+
+	for _, tt := range nonDetTests {
+		t.Run(tt.name+"_nondet", func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic (column reference)\nSQL: %s", tt.sql)
+			}
+			if !strings.Contains(result.Reason, "column reference") {
+				t.Errorf("expected reason about column reference, got: %s", result.Reason)
+			}
+		})
+	}
+
+	// Deterministic UPDATE SET (literals only)
+	detTests := []struct {
+		name string
+		sql  string
+	}{
+		{"SET literal string", "UPDATE t SET x = 'value' WHERE id = 1"},
+		{"SET literal number", "UPDATE t SET x = 42 WHERE id = 1"},
+		{"SET literal with expression", "UPDATE t SET x = 10 + 20 WHERE id = 1"},
+		{"SET NULL", "UPDATE t SET x = NULL WHERE id = 1"},
+		{"SET deterministic function", "UPDATE t SET x = upper('test') WHERE id = 1"},
+		{"SET multiple literals", "UPDATE t SET x = 'a', y = 'b', z = 1 WHERE id = 1"},
+		{"SET with coalesce on literals", "UPDATE t SET x = coalesce('a', 'b') WHERE id = 1"},
+	}
+
+	for _, tt := range detTests {
+		t.Run(tt.name+"_det", func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if !result.IsDeterministic {
+				t.Errorf("expected deterministic, reason=%s\nSQL: %s", result.Reason, tt.sql)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_Subqueries tests various subquery patterns
+func TestCheckSQL_Subqueries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		// INSERT ... SELECT
+		{"INSERT SELECT all", "INSERT INTO archive SELECT * FROM users"},
+		{"INSERT SELECT specific columns", "INSERT INTO t (a, b) SELECT x, y FROM src"},
+		{"INSERT SELECT with WHERE", "INSERT INTO archive SELECT * FROM users WHERE status = 'inactive'"},
+		{"INSERT SELECT with ORDER BY", "INSERT INTO t (a) SELECT x FROM src ORDER BY x"},
+		{"INSERT SELECT with LIMIT", "INSERT INTO t (a) SELECT x FROM src LIMIT 10"},
+		{"INSERT SELECT with JOIN", "INSERT INTO t (a, b) SELECT u.x, o.y FROM users u JOIN orders o ON u.id = o.user_id"},
+
+		// UPDATE with scalar subquery in SET
+		{"UPDATE SET scalar subquery", "UPDATE t SET x = (SELECT max(y) FROM src) WHERE id = 1"},
+		{"UPDATE SET scalar subquery with WHERE", "UPDATE users SET total = (SELECT sum(amount) FROM orders WHERE user_id = users.id) WHERE status = 'active'"},
+		{"UPDATE SET correlated subquery", "UPDATE t SET x = (SELECT y FROM src WHERE src.id = t.ref_id) WHERE id = 1"},
+
+		// DELETE with subquery in WHERE
+		{"DELETE IN subquery", "DELETE FROM users WHERE id IN (SELECT user_id FROM banned)"},
+		{"DELETE EXISTS subquery", "DELETE FROM users WHERE EXISTS (SELECT 1 FROM banned WHERE banned.user_id = users.id)"},
+		{"DELETE NOT IN subquery", "DELETE FROM users WHERE id NOT IN (SELECT user_id FROM active_users)"},
+
+		// UPDATE with subquery in WHERE
+		{"UPDATE WHERE IN subquery", "UPDATE users SET status = 'banned' WHERE id IN (SELECT user_id FROM violations)"},
+		{"UPDATE WHERE EXISTS", "UPDATE users SET active = 0 WHERE EXISTS (SELECT 1 FROM deleted WHERE deleted.user_id = users.id)"},
+
+		// Nested subqueries
+		{"nested subquery", "INSERT INTO t (a) SELECT x FROM (SELECT y AS x FROM src)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic (subquery)\nSQL: %s", tt.sql)
+			}
+			if !strings.Contains(result.Reason, "subquery") {
+				t.Errorf("expected reason about subquery, got: %s", result.Reason)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_DeleteLimitNoOrderBy tests DELETE with LIMIT but no ORDER BY
+func TestCheckSQL_DeleteLimitNoOrderBy(t *testing.T) {
+	t.Parallel()
+
+	nonDetTests := []struct {
+		name string
+		sql  string
+	}{
+		{"DELETE LIMIT 1", "DELETE FROM t LIMIT 1"},
+		{"DELETE LIMIT 10", "DELETE FROM t LIMIT 10"},
+		{"DELETE WHERE LIMIT", "DELETE FROM t WHERE status = 'old' LIMIT 5"},
+		{"DELETE WHERE AND LIMIT", "DELETE FROM t WHERE a = 1 AND b = 2 LIMIT 100"},
+	}
+
+	for _, tt := range nonDetTests {
+		t.Run(tt.name+"_nondet", func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic\nSQL: %s", tt.sql)
+			}
+			if !strings.Contains(result.Reason, "LIMIT") {
+				t.Errorf("expected reason about LIMIT, got: %s", result.Reason)
+			}
+		})
+	}
+
+	// Deterministic DELETE with LIMIT and ORDER BY
+	detTests := []struct {
+		name string
+		sql  string
+	}{
+		{"DELETE ORDER BY LIMIT", "DELETE FROM t ORDER BY id LIMIT 10"},
+		{"DELETE WHERE ORDER BY LIMIT", "DELETE FROM t WHERE status = 'old' ORDER BY created_at LIMIT 5"},
+		{"DELETE ORDER BY DESC LIMIT", "DELETE FROM t ORDER BY id DESC LIMIT 1"},
+		{"DELETE multiple ORDER BY LIMIT", "DELETE FROM t ORDER BY a, b LIMIT 10"},
+		{"DELETE without LIMIT", "DELETE FROM t WHERE id = 1"},
+		{"DELETE all", "DELETE FROM t"},
+	}
+
+	for _, tt := range detTests {
+		t.Run(tt.name+"_det", func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if !result.IsDeterministic {
+				t.Errorf("expected deterministic, reason=%s\nSQL: %s", result.Reason, tt.sql)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_UnknownFunctions tests that unknown functions are flagged as non-deterministic
+func TestCheckSQL_UnknownFunctions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		sql      string
+		funcName string
+	}{
+		{"custom_func", "INSERT INTO t (v) VALUES (custom_func())", "custom_func"},
+		{"my_udf", "INSERT INTO t (v) VALUES (my_udf(1, 2))", "my_udf"},
+		{"app_specific", "INSERT INTO t (v) VALUES (app_specific('arg'))", "app_specific"},
+		{"calculate", "UPDATE t SET v = calculate(x, y) WHERE id = 1", "calculate"},
+		{"process", "INSERT INTO t (v) VALUES (process('data'))", "process"},
+		{"unknown123", "INSERT INTO t (v) VALUES (unknown123())", "unknown123"},
+
+		// SQLite extension functions that aren't in whitelist
+		{"compress", "INSERT INTO t (v) VALUES (compress('data'))", "compress"},
+		{"decompress", "INSERT INTO t (v) VALUES (decompress(blob))", "decompress"},
+
+		// Functions with similar names to known ones
+		{"random2", "INSERT INTO t (v) VALUES (random2())", "random2"},
+		{"my_random", "INSERT INTO t (v) VALUES (my_random())", "my_random"},
+		{"abs2", "INSERT INTO t (v) VALUES (abs2(-1))", "abs2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic (unknown function)\nSQL: %s", tt.sql)
+			}
+			if !strings.Contains(result.Reason, "unknown function") {
+				t.Errorf("expected reason about unknown function, got: %s", result.Reason)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_NestedNonDeterministic tests nested function calls with non-deterministic inner functions
+func TestCheckSQL_NestedNonDeterministic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sql        string
+		wantReason string
+	}{
+		// random() nested
+		{"abs(random())", "INSERT INTO t (v) VALUES (abs(random()))", "random"},
+		{"round(random())", "INSERT INTO t (v) VALUES (round(random()))", "random"},
+		{"hex(randomblob(4))", "INSERT INTO t (v) VALUES (hex(randomblob(4)))", "randomblob"},
+		{"upper(hex(randomblob(8)))", "INSERT INTO t (v) VALUES (upper(hex(randomblob(8))))", "randomblob"},
+		{"length(hex(random()))", "INSERT INTO t (v) VALUES (length(hex(random())))", "random"},
+		{"substr(hex(random()), 1, 4)", "INSERT INTO t (v) VALUES (substr(hex(random()), 1, 4))", "random"},
+
+		// datetime('now') nested
+		{"upper(datetime('now'))", "INSERT INTO t (v) VALUES (upper(datetime('now')))", "datetime"},
+		{"length(date('now'))", "INSERT INTO t (v) VALUES (length(date('now')))", "date"},
+		{"substr(time('now'), 1, 2)", "INSERT INTO t (v) VALUES (substr(time('now'), 1, 2))", "time"},
+		{"coalesce(NULL, datetime('now'))", "INSERT INTO t (v) VALUES (coalesce(NULL, datetime('now')))", "datetime"},
+		{"ifnull(NULL, date('now'))", "INSERT INTO t (v) VALUES (ifnull(NULL, date('now')))", "date"},
+
+		// Multiple levels of nesting
+		{"upper(lower(hex(random())))", "INSERT INTO t (v) VALUES (upper(lower(hex(random()))))", "random"},
+		{"substr(upper(datetime('now')), 1, 10)", "INSERT INTO t (v) VALUES (substr(upper(datetime('now')), 1, 10))", "datetime"},
+		{"coalesce(ifnull(NULL, random()), 0)", "INSERT INTO t (v) VALUES (coalesce(ifnull(NULL, random()), 0))", "random"},
+
+		// Non-deterministic in CASE
+		{"CASE with random()", "INSERT INTO t (v) VALUES (CASE WHEN random() > 0 THEN 1 ELSE 0 END)", "random"},
+		{"CASE result random()", "INSERT INTO t (v) VALUES (CASE WHEN 1=1 THEN random() ELSE 0 END)", "random"},
+
+		// In coalesce/ifnull
+		{"coalesce with random", "INSERT INTO t (v) VALUES (coalesce(random(), 0))", "random"},
+		{"ifnull with datetime", "INSERT INTO t (v) VALUES (ifnull(NULL, datetime('now')))", "datetime"},
+
+		// iif with non-deterministic
+		{"iif with random", "INSERT INTO t (v) VALUES (iif(random() > 0, 'a', 'b'))", "random"},
+
+		// CURRENT_* nested
+		{"upper(CURRENT_DATE)", "INSERT INTO t (v) VALUES (upper(CURRENT_DATE))", ""},
+		{"coalesce(NULL, CURRENT_TIMESTAMP)", "INSERT INTO t (v) VALUES (coalesce(NULL, CURRENT_TIMESTAMP))", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic\nSQL: %s", tt.sql)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_MixedDeterministicNonDeterministic tests statements with both det and non-det functions
+func TestCheckSQL_MixedDeterministicNonDeterministic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		// Multiple columns, one non-deterministic
+		{"one column non-det", "INSERT INTO t (a, b, c) VALUES (1, 'test', random())"},
+		{"first column non-det", "INSERT INTO t (a, b, c) VALUES (random(), 'test', 123)"},
+		{"middle column non-det", "INSERT INTO t (a, b, c) VALUES (1, datetime('now'), 123)"},
+
+		// Deterministic and non-deterministic in same expression
+		{"det + non-det arithmetic", "INSERT INTO t (v) VALUES (10 + random())"},
+		{"det || non-det concat", "INSERT INTO t (v) VALUES ('prefix_' || hex(random()))"},
+
+		// Multiple non-deterministic in one statement
+		{"multiple random()", "INSERT INTO t (a, b) VALUES (random(), random())"},
+		{"random and datetime", "INSERT INTO t (a, b) VALUES (random(), datetime('now'))"},
+		{"three non-det", "INSERT INTO t (a, b, c) VALUES (random(), datetime('now'), last_insert_rowid())"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if result.IsDeterministic {
+				t.Errorf("expected non-deterministic\nSQL: %s", tt.sql)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_ParseErrors tests handling of invalid SQL
+func TestCheckSQL_ParseErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"incomplete INSERT", "INSERT INTO"},
+		{"invalid syntax", "INSERT INTO t VALUES (("},
+		{"empty string", ""},
+		{"garbage", "asdfghjkl"},
+		{"missing VALUES", "INSERT INTO t (a)"},
+		{"unclosed string", "INSERT INTO t (a) VALUES ('unclosed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			// Parse errors should be non-deterministic (fail-safe)
+			if result.IsDeterministic {
+				t.Errorf("parse error should result in non-deterministic\nSQL: %s", tt.sql)
+			}
+			if !strings.Contains(result.Reason, "parse error") {
+				t.Errorf("expected parse error reason, got: %s", result.Reason)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_DeterministicFunctionVariants tests various deterministic function patterns
+func TestCheckSQL_DeterministicFunctionVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		// Math functions
+		{"abs(-42)", "INSERT INTO t (v) VALUES (abs(-42))"},
+		{"round(3.14159, 2)", "INSERT INTO t (v) VALUES (round(3.14159, 2))"},
+		{"min(1, 2, 3)", "INSERT INTO t (v) VALUES (min(1, 2, 3))"},
+		{"max(1, 2, 3)", "INSERT INTO t (v) VALUES (max(1, 2, 3))"},
+		{"sign(-5)", "INSERT INTO t (v) VALUES (sign(-5))"},
+
+		// String functions
+		{"upper('hello')", "INSERT INTO t (v) VALUES (upper('hello'))"},
+		{"lower('HELLO')", "INSERT INTO t (v) VALUES (lower('HELLO'))"},
+		{"trim('  hello  ')", "INSERT INTO t (v) VALUES (trim('  hello  '))"},
+		{"ltrim('  hello')", "INSERT INTO t (v) VALUES (ltrim('  hello'))"},
+		{"rtrim('hello  ')", "INSERT INTO t (v) VALUES (rtrim('hello  '))"},
+		{"length('hello')", "INSERT INTO t (v) VALUES (length('hello'))"},
+		{"substr('hello', 2, 3)", "INSERT INTO t (v) VALUES (substr('hello', 2, 3))"},
+		{"substring('hello', 2, 3)", "INSERT INTO t (v) VALUES (substring('hello', 2, 3))"},
+		// Note: replace() not tested - rqlite/sql parser treats REPLACE as keyword
+		{"instr('hello', 'l')", "INSERT INTO t (v) VALUES (instr('hello', 'l'))"},
+		{"hex('hello')", "INSERT INTO t (v) VALUES (hex('hello'))"},
+		{"quote('hello')", "INSERT INTO t (v) VALUES (quote('hello'))"},
+		{"printf('%d', 42)", "INSERT INTO t (v) VALUES (printf('%d', 42))"},
+		{"format('%s', 'test')", "INSERT INTO t (v) VALUES (format('%s', 'test'))"},
+
+		// Null handling
+		{"coalesce(NULL, 'default')", "INSERT INTO t (v) VALUES (coalesce(NULL, 'default'))"},
+		{"ifnull(NULL, 'default')", "INSERT INTO t (v) VALUES (ifnull(NULL, 'default'))"},
+		{"nullif('a', 'b')", "INSERT INTO t (v) VALUES (nullif('a', 'b'))"},
+		{"iif(1=1, 'yes', 'no')", "INSERT INTO t (v) VALUES (iif(1=1, 'yes', 'no'))"},
+
+		// JSON functions
+		{"json_extract('{\"a\":1}', '$.a')", "INSERT INTO t (v) VALUES (json_extract('{\"a\":1}', '$.a'))"},
+		{"json_object('a', 1)", "INSERT INTO t (v) VALUES (json_object('a', 1))"},
+		{"json_array(1, 2, 3)", "INSERT INTO t (v) VALUES (json_array(1, 2, 3))"},
+		{"json_valid('{}')", "INSERT INTO t (v) VALUES (json_valid('{}'))"},
+
+		// Type functions
+		{"typeof(42)", "INSERT INTO t (v) VALUES (typeof(42))"},
+		{"zeroblob(10)", "INSERT INTO t (v) VALUES (zeroblob(10))"},
+
+		// Nested deterministic
+		{"upper(trim(lower('  HELLO  ')))", "INSERT INTO t (v) VALUES (upper(trim(lower('  HELLO  '))))"},
+		{"coalesce(nullif('', ''), 'default')", "INSERT INTO t (v) VALUES (coalesce(nullif('', ''), 'default'))"},
+		{"abs(min(-1, -2, -3))", "INSERT INTO t (v) VALUES (abs(min(-1, -2, -3)))"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if !result.IsDeterministic {
+				t.Errorf("expected deterministic, reason=%s\nSQL: %s", result.Reason, tt.sql)
+			}
+		})
+	}
+}
+
+// TestCheckSQL_WhereClauseDoesNotAffectDeterminism tests that WHERE clause columns don't affect determinism
+func TestCheckSQL_WhereClauseDoesNotAffectDeterminism(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		// UPDATE with column in WHERE only
+		{"UPDATE column in WHERE", "UPDATE t SET x = 'value' WHERE y = 1"},
+		{"UPDATE column comparison in WHERE", "UPDATE t SET x = 'value' WHERE a = b"},
+		{"UPDATE column LIKE in WHERE", "UPDATE t SET status = 'new' WHERE name LIKE 'test%'"},
+		{"UPDATE column function in WHERE", "UPDATE t SET status = 'lower' WHERE upper(name) = 'TEST'"},
+
+		// DELETE with column in WHERE
+		{"DELETE column in WHERE", "DELETE FROM t WHERE id = 1"},
+		{"DELETE column comparison", "DELETE FROM t WHERE a = b"},
+		{"DELETE column BETWEEN", "DELETE FROM t WHERE x BETWEEN y AND z"},
+		{"DELETE column IN list", "DELETE FROM t WHERE status IN ('a', 'b')"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQL(tt.sql)
+			if !result.IsDeterministic {
+				t.Errorf("expected deterministic (column in WHERE should be OK), reason=%s\nSQL: %s",
+					result.Reason, tt.sql)
+			}
+		})
+	}
+}
+
+// TestResult_Fields tests the Result struct fields
+func TestResult_Fields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deterministic result", func(t *testing.T) {
+		result := CheckSQL("INSERT INTO t (id) VALUES (1)")
+		if !result.IsDeterministic {
+			t.Error("expected IsDeterministic=true")
+		}
+		if result.Reason != "" {
+			t.Errorf("expected empty reason, got: %s", result.Reason)
+		}
+		if len(result.NonDetFunctions) != 0 {
+			t.Errorf("expected empty NonDetFunctions, got: %v", result.NonDetFunctions)
+		}
+	})
+
+	t.Run("non-deterministic with single function", func(t *testing.T) {
+		result := CheckSQL("INSERT INTO t (id) VALUES (random())")
+		if result.IsDeterministic {
+			t.Error("expected IsDeterministic=false")
+		}
+		if result.Reason == "" {
+			t.Error("expected non-empty reason")
+		}
+		if len(result.NonDetFunctions) == 0 {
+			t.Error("expected NonDetFunctions to contain the function")
+		}
+	})
+
+	t.Run("non-deterministic with multiple functions", func(t *testing.T) {
+		result := CheckSQL("INSERT INTO t (a, b) VALUES (random(), datetime('now'))")
+		if result.IsDeterministic {
+			t.Error("expected IsDeterministic=false")
+		}
+		if len(result.NonDetFunctions) < 2 {
+			t.Errorf("expected at least 2 NonDetFunctions, got: %v", result.NonDetFunctions)
+		}
+	})
+}
+
+// BenchmarkCheckSQL benchmarks the determinism checker
+func BenchmarkCheckSQL(b *testing.B) {
+	sqls := []string{
+		"INSERT INTO users (id, name) VALUES (1, 'Alice')",
+		"INSERT INTO users (id, created) VALUES (1, datetime('now'))",
+		"UPDATE users SET name = upper('test') WHERE id = 1",
+		"UPDATE users SET counter = counter + 1 WHERE id = 1",
+		"DELETE FROM users WHERE id IN (1, 2, 3)",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, sql := range sqls {
+			CheckSQL(sql)
+		}
+	}
+}
+
+// BenchmarkCheckSQL_Complex benchmarks complex SQL statements
+func BenchmarkCheckSQL_Complex(b *testing.B) {
+	sqls := []string{
+		"INSERT INTO t (a, b, c, d, e) VALUES (upper(lower(trim('  test  '))), coalesce(NULL, 'default'), abs(round(-3.14, 2)), hex('data'), json_object('key', 'value'))",
+		"UPDATE t SET a = upper('x'), b = lower('Y'), c = 'literal', d = 42 WHERE id = 1 AND status = 'active' AND created < '2024-01-01'",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, sql := range sqls {
+			CheckSQL(sql)
+		}
+	}
+}

--- a/protocol/determinism/schema.go
+++ b/protocol/determinism/schema.go
@@ -1,0 +1,425 @@
+package determinism
+
+import (
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/rqlite/sql"
+)
+
+// Cache size for parsed CREATE TABLE/TRIGGER statements
+const schemaCacheSize = 1024
+
+// tableCache caches parsed TableInfo keyed by XXH64 hash of CREATE TABLE SQL
+var tableCache *lru.Cache[uint64, *TableInfo]
+
+// triggerCache caches trigger parsing results keyed by XXH64 hash of CREATE TRIGGER SQL
+type triggerCacheEntry struct {
+	tableName       string
+	isDeterministic bool
+}
+
+var triggerCache *lru.Cache[uint64, *triggerCacheEntry]
+
+func init() {
+	var err error
+	tableCache, err = lru.New[uint64, *TableInfo](schemaCacheSize)
+	if err != nil {
+		panic("failed to create table cache: " + err.Error())
+	}
+	triggerCache, err = lru.New[uint64, *triggerCacheEntry](schemaCacheSize)
+	if err != nil {
+		panic("failed to create trigger cache: " + err.Error())
+	}
+}
+
+// Schema holds table metadata for schema-aware determinism checking.
+// Build this from CREATE TABLE and CREATE TRIGGER statements.
+type Schema struct {
+	Tables map[string]*TableInfo
+}
+
+// TableInfo holds metadata about a single table.
+type TableInfo struct {
+	Name       string
+	Columns    map[string]*ColumnInfo
+	HasTrigger bool // true if any trigger exists on this table
+}
+
+// ColumnInfo holds metadata about a single column.
+type ColumnInfo struct {
+	Name                   string
+	HasDefault             bool
+	DefaultIsDeterministic bool
+}
+
+// NewSchema creates an empty schema.
+func NewSchema() *Schema {
+	return &Schema{
+		Tables: make(map[string]*TableInfo),
+	}
+}
+
+// AddTable adds or updates table info from a CREATE TABLE statement.
+// Uses XXH64-keyed LRU cache to avoid re-parsing identical SQL.
+func (s *Schema) AddTable(createSQL string) error {
+	hash := xxhash.Sum64String(createSQL)
+
+	// Check cache first
+	if cached, ok := tableCache.Get(hash); ok {
+		// Clone - HasTrigger is per-schema state, not cached
+		table := &TableInfo{
+			Name:       cached.Name,
+			Columns:    cached.Columns,
+			HasTrigger: false, // Reset - this is set by AddTrigger, not cached
+		}
+		if existing, ok := s.Tables[cached.Name]; ok {
+			table.HasTrigger = existing.HasTrigger
+		}
+		s.Tables[table.Name] = table
+		return nil
+	}
+
+	// Parse and cache
+	parser := sql.NewParser(strings.NewReader(createSQL))
+	stmt, err := parser.ParseStatement()
+	if err != nil {
+		return err
+	}
+
+	create, ok := stmt.(*sql.CreateTableStatement)
+	if !ok {
+		return nil // not a CREATE TABLE, ignore
+	}
+
+	tableName := strings.ToLower(create.Name.Name)
+	table := &TableInfo{
+		Name:    tableName,
+		Columns: make(map[string]*ColumnInfo),
+	}
+
+	for _, col := range create.Columns {
+		colInfo := &ColumnInfo{
+			Name:                   strings.ToLower(col.Name.Name),
+			HasDefault:             false,
+			DefaultIsDeterministic: true,
+		}
+
+		// Check for DEFAULT constraint
+		for _, constraint := range col.Constraints {
+			if defConstraint, ok := constraint.(*sql.DefaultConstraint); ok {
+				colInfo.HasDefault = true
+				colInfo.DefaultIsDeterministic = isExprDeterministic(defConstraint.Expr)
+			}
+		}
+
+		table.Columns[colInfo.Name] = colInfo
+	}
+
+	// Cache the parsed result (without HasTrigger - that's per-schema state)
+	tableCache.Add(hash, table)
+
+	// Check if table already exists (might have trigger info)
+	if existing, ok := s.Tables[tableName]; ok {
+		table.HasTrigger = existing.HasTrigger
+	}
+
+	s.Tables[tableName] = table
+	return nil
+}
+
+// AddTrigger marks a table as having a trigger.
+// Uses XXH64-keyed LRU cache to avoid re-parsing identical SQL.
+// For fail-safe, any table with non-deterministic triggers is marked.
+func (s *Schema) AddTrigger(createSQL string) error {
+	hash := xxhash.Sum64String(createSQL)
+
+	// Check cache first
+	if cached, ok := triggerCache.Get(hash); ok {
+		if !cached.isDeterministic {
+			// Get or create table info
+			table, ok := s.Tables[cached.tableName]
+			if !ok {
+				table = &TableInfo{
+					Name:    cached.tableName,
+					Columns: make(map[string]*ColumnInfo),
+				}
+				s.Tables[cached.tableName] = table
+			}
+			table.HasTrigger = true
+		}
+		return nil
+	}
+
+	// Parse and cache
+	parser := sql.NewParser(strings.NewReader(createSQL))
+	stmt, err := parser.ParseStatement()
+	if err != nil {
+		return err
+	}
+
+	trigger, ok := stmt.(*sql.CreateTriggerStatement)
+	if !ok {
+		return nil // not a CREATE TRIGGER, ignore
+	}
+
+	tableName := strings.ToLower(trigger.Table.Name)
+
+	// Check if trigger body contains non-deterministic expressions
+	triggerIsDet := isTriggerBodyDeterministic(trigger)
+
+	// Cache the result
+	triggerCache.Add(hash, &triggerCacheEntry{
+		tableName:       tableName,
+		isDeterministic: triggerIsDet,
+	})
+
+	if !triggerIsDet {
+		// Get or create table info
+		table, ok := s.Tables[tableName]
+		if !ok {
+			table = &TableInfo{
+				Name:    tableName,
+				Columns: make(map[string]*ColumnInfo),
+			}
+			s.Tables[tableName] = table
+		}
+		table.HasTrigger = true
+	}
+
+	return nil
+}
+
+// DropTable removes a table from the schema.
+func (s *Schema) DropTable(tableName string) {
+	delete(s.Tables, strings.ToLower(tableName))
+}
+
+// DropTrigger would need trigger name tracking - for now, triggers stay marked.
+// In practice, you'd rebuild schema periodically or track trigger names.
+
+// isExprDeterministic checks if a DEFAULT expression is deterministic.
+func isExprDeterministic(expr sql.Expr) bool {
+	checker := &exprDeterminismChecker{}
+	sql.Walk(checker, expr)
+	return checker.isDeterministic
+}
+
+// exprDeterminismChecker walks an expression AST to check for non-deterministic elements.
+type exprDeterminismChecker struct {
+	isDeterministic bool
+}
+
+func (c *exprDeterminismChecker) Visit(node sql.Node) (sql.Visitor, sql.Node, error) {
+	// Initialize as deterministic on first visit
+	if !c.isDeterministic && node != nil {
+		c.isDeterministic = true
+	}
+
+	switch n := node.(type) {
+	case *sql.Call:
+		name := strings.ToLower(n.Name.Name)
+		if nonDeterministicFunctions[name] {
+			c.isDeterministic = false
+			return nil, node, nil
+		}
+		if timeFunctionsWithNow[name] && hasNowArg(n) {
+			c.isDeterministic = false
+			return nil, node, nil
+		}
+		if !deterministicFunctions[name] && !timeFunctionsWithNow[name] {
+			// Unknown function - fail safe
+			c.isDeterministic = false
+			return nil, node, nil
+		}
+	case *sql.Ident:
+		name := strings.ToLower(n.Name)
+		if nonDeterministicIdents[name] {
+			c.isDeterministic = false
+			return nil, node, nil
+		}
+	case *sql.TimestampLit:
+		// CURRENT_TIMESTAMP, CURRENT_DATE, CURRENT_TIME literals
+		c.isDeterministic = false
+		return nil, node, nil
+	}
+	return c, node, nil
+}
+
+func (c *exprDeterminismChecker) VisitEnd(node sql.Node) (sql.Node, error) {
+	return node, nil
+}
+
+// hasNowArg checks if a time function call has 'now' as an argument.
+func hasNowArg(call *sql.Call) bool {
+	name := strings.ToLower(call.Name.Name)
+
+	if name == "strftime" {
+		if len(call.Args) <= 1 {
+			return true
+		}
+		if len(call.Args) >= 2 {
+			if lit, ok := call.Args[1].(*sql.StringLit); ok {
+				if strings.ToLower(lit.Value) == "now" {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	if len(call.Args) == 0 {
+		return true
+	}
+
+	if lit, ok := call.Args[0].(*sql.StringLit); ok {
+		if strings.ToLower(lit.Value) == "now" {
+			return true
+		}
+	}
+	return false
+}
+
+// isTriggerBodyDeterministic checks if a trigger body is deterministic.
+// Only DML statements (INSERT/UPDATE/DELETE) matter for replication.
+func isTriggerBodyDeterministic(trigger *sql.CreateTriggerStatement) bool {
+	for _, stmt := range trigger.Body {
+		// Only check DML statements - SELECT doesn't modify data
+		switch stmt.(type) {
+		case *sql.InsertStatement, *sql.UpdateStatement, *sql.DeleteStatement:
+			result := CheckStatement(stmt)
+			if !result.IsDeterministic {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// CheckSQLWithSchema checks a DML statement with schema context.
+// This detects non-determinism from:
+// - DEFAULT values with non-deterministic expressions (when column not specified in INSERT)
+// - Tables with non-deterministic triggers
+func CheckSQLWithSchema(sqlStr string, schema *Schema) Result {
+	// First do the basic check
+	result := CheckSQL(sqlStr)
+	if !result.IsDeterministic {
+		return result
+	}
+
+	if schema == nil {
+		return result
+	}
+
+	// Parse to get statement details
+	parser := sql.NewParser(strings.NewReader(sqlStr))
+	stmt, err := parser.ParseStatement()
+	if err != nil {
+		return result // already checked above
+	}
+
+	return checkStatementWithSchema(stmt, schema)
+}
+
+// CheckStatementWithSchema checks a parsed statement with schema context.
+func CheckStatementWithSchema(stmt sql.Statement, schema *Schema) Result {
+	// First do the basic check
+	result := CheckStatement(stmt)
+	if !result.IsDeterministic {
+		return result
+	}
+
+	if schema == nil {
+		return result
+	}
+
+	return checkStatementWithSchema(stmt, schema)
+}
+
+func checkStatementWithSchema(stmt sql.Statement, schema *Schema) Result {
+	switch s := stmt.(type) {
+	case *sql.InsertStatement:
+		return checkInsertWithSchema(s, schema)
+	case *sql.UpdateStatement:
+		return checkUpdateWithSchema(s, schema)
+	case *sql.DeleteStatement:
+		return checkDeleteWithSchema(s, schema)
+	}
+	return Result{IsDeterministic: true}
+}
+
+func checkInsertWithSchema(stmt *sql.InsertStatement, schema *Schema) Result {
+	tableName := strings.ToLower(stmt.Table.Name)
+	table, ok := schema.Tables[tableName]
+	if !ok {
+		// Unknown table - can't check schema, assume OK
+		return Result{IsDeterministic: true}
+	}
+
+	// Check for triggers
+	if table.HasTrigger {
+		return Result{
+			IsDeterministic: false,
+			Reason:          "table has non-deterministic trigger: " + tableName,
+		}
+	}
+
+	// Check for non-deterministic DEFAULTs on columns not in INSERT
+	if len(stmt.Columns) > 0 {
+		// Explicit column list - check which columns are missing
+		specifiedCols := make(map[string]bool)
+		for _, col := range stmt.Columns {
+			specifiedCols[strings.ToLower(col.Name)] = true
+		}
+
+		for colName, colInfo := range table.Columns {
+			if !specifiedCols[colName] && colInfo.HasDefault && !colInfo.DefaultIsDeterministic {
+				return Result{
+					IsDeterministic: false,
+					Reason:          "column '" + colName + "' has non-deterministic DEFAULT",
+				}
+			}
+		}
+	}
+	// If no column list, all columns must be provided or have deterministic defaults
+	// This is harder to check without knowing the value count, so we're lenient here
+
+	return Result{IsDeterministic: true}
+}
+
+func checkUpdateWithSchema(stmt *sql.UpdateStatement, schema *Schema) Result {
+	tableName := strings.ToLower(stmt.Table.Name.Name)
+	table, ok := schema.Tables[tableName]
+	if !ok {
+		return Result{IsDeterministic: true}
+	}
+
+	// Check for triggers
+	if table.HasTrigger {
+		return Result{
+			IsDeterministic: false,
+			Reason:          "table has non-deterministic trigger: " + tableName,
+		}
+	}
+
+	return Result{IsDeterministic: true}
+}
+
+func checkDeleteWithSchema(stmt *sql.DeleteStatement, schema *Schema) Result {
+	tableName := strings.ToLower(stmt.Table.Name.Name)
+	table, ok := schema.Tables[tableName]
+	if !ok {
+		return Result{IsDeterministic: true}
+	}
+
+	// Check for triggers
+	if table.HasTrigger {
+		return Result{
+			IsDeterministic: false,
+			Reason:          "table has non-deterministic trigger: " + tableName,
+		}
+	}
+
+	return Result{IsDeterministic: true}
+}

--- a/protocol/determinism/schema_test.go
+++ b/protocol/determinism/schema_test.go
@@ -1,0 +1,1072 @@
+package determinism
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rqlite/sql"
+)
+
+func TestSchema_AddTable(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	err := schema.AddTable(`CREATE TABLE users (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		status TEXT DEFAULT 'active'
+	)`)
+	if err != nil {
+		t.Fatalf("AddTable failed: %v", err)
+	}
+
+	table, ok := schema.Tables["users"]
+	if !ok {
+		t.Fatal("users table not found")
+	}
+
+	// Check created_at has non-det DEFAULT
+	createdAt := table.Columns["created_at"]
+	if !createdAt.HasDefault {
+		t.Error("created_at should have default")
+	}
+	if createdAt.DefaultIsDeterministic {
+		t.Error("created_at DEFAULT CURRENT_TIMESTAMP should be non-deterministic")
+	}
+
+	// Check status has deterministic DEFAULT
+	status := table.Columns["status"]
+	if !status.HasDefault {
+		t.Error("status should have default")
+	}
+	if !status.DefaultIsDeterministic {
+		t.Error("status DEFAULT 'active' should be deterministic")
+	}
+}
+
+func TestSchema_AddTrigger(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE audit_log (id INTEGER, msg TEXT)`)
+	schema.AddTable(`CREATE TABLE audit_backup (id INTEGER, msg TEXT)`)
+
+	// Add trigger with non-deterministic DML body
+	err := schema.AddTrigger(`CREATE TRIGGER log_changes AFTER INSERT ON audit_log
+		BEGIN
+			INSERT INTO audit_backup (id, msg) VALUES (random(), 'backup');
+		END`)
+	if err != nil {
+		t.Fatalf("AddTrigger failed: %v", err)
+	}
+
+	table := schema.Tables["audit_log"]
+	if !table.HasTrigger {
+		t.Error("audit_log should have trigger marked")
+	}
+}
+
+func TestCheckSQLWithSchema_NonDetDefault(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE events (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`)
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantDet bool
+	}{
+		{
+			name:    "INSERT missing non-det DEFAULT column",
+			sql:     "INSERT INTO events (id, name) VALUES (1, 'test')",
+			wantDet: false,
+		},
+		{
+			name:    "INSERT all columns specified",
+			sql:     "INSERT INTO events (id, name, created_at) VALUES (1, 'test', '2024-01-01')",
+			wantDet: true,
+		},
+		{
+			name:    "INSERT missing only det columns",
+			sql:     "INSERT INTO events (id, created_at) VALUES (1, '2024-01-01')",
+			wantDet: true, // name has no DEFAULT, will be NULL
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQLWithSchema(tt.sql, schema)
+			if result.IsDeterministic != tt.wantDet {
+				t.Errorf("got IsDeterministic=%v, want %v, reason=%s",
+					result.IsDeterministic, tt.wantDet, result.Reason)
+			}
+		})
+	}
+}
+
+func TestCheckSQLWithSchema_Trigger(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE tracked (id INTEGER, data TEXT)`)
+	schema.AddTable(`CREATE TABLE tracked_log (ts TEXT)`)
+	schema.AddTrigger(`CREATE TRIGGER track_insert AFTER INSERT ON tracked
+		BEGIN
+			INSERT INTO tracked_log (ts) VALUES (datetime('now'));
+		END`)
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantDet bool
+	}{
+		{
+			name:    "INSERT to table with non-det trigger",
+			sql:     "INSERT INTO tracked (id, data) VALUES (1, 'test')",
+			wantDet: false,
+		},
+		{
+			name:    "UPDATE table with non-det trigger",
+			sql:     "UPDATE tracked SET data = 'new' WHERE id = 1",
+			wantDet: false,
+		},
+		{
+			name:    "DELETE from table with non-det trigger",
+			sql:     "DELETE FROM tracked WHERE id = 1",
+			wantDet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQLWithSchema(tt.sql, schema)
+			if result.IsDeterministic != tt.wantDet {
+				t.Errorf("got IsDeterministic=%v, want %v, reason=%s",
+					result.IsDeterministic, tt.wantDet, result.Reason)
+			}
+		})
+	}
+}
+
+func TestCheckSQLWithSchema_DetTrigger(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE simple (id INTEGER, data TEXT)`)
+	schema.AddTable(`CREATE TABLE simple_log (id INTEGER, data TEXT)`)
+	// Deterministic trigger - DML with literals only
+	schema.AddTrigger(`CREATE TRIGGER simple_trigger AFTER INSERT ON simple
+		BEGIN
+			INSERT INTO simple_log (id, data) VALUES (1, 'logged');
+		END`)
+
+	result := CheckSQLWithSchema("INSERT INTO simple (id, data) VALUES (1, 'test')", schema)
+	if !result.IsDeterministic {
+		t.Errorf("deterministic trigger should not flag table, reason=%s", result.Reason)
+	}
+}
+
+func TestCheckSQLWithSchema_UnknownTable(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	// Empty schema - unknown tables should pass through
+
+	result := CheckSQLWithSchema("INSERT INTO unknown (id) VALUES (1)", schema)
+	if !result.IsDeterministic {
+		t.Errorf("unknown table should be deterministic, reason=%s", result.Reason)
+	}
+}
+
+func TestCheckSQLWithSchema_NilSchema(t *testing.T) {
+	t.Parallel()
+
+	// Nil schema should just do basic check
+	result := CheckSQLWithSchema("INSERT INTO t (id) VALUES (1)", nil)
+	if !result.IsDeterministic {
+		t.Error("nil schema should pass through basic check")
+	}
+
+	result = CheckSQLWithSchema("INSERT INTO t (id) VALUES (random())", nil)
+	if result.IsDeterministic {
+		t.Error("random() should still be detected with nil schema")
+	}
+}
+
+// TestSchema_AllCurrentTimeDefaults tests all current time DEFAULT variants
+func TestSchema_AllCurrentTimeDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		createSQL  string
+		colName    string
+		wantNonDet bool
+	}{
+		{"CURRENT_TIMESTAMP", `CREATE TABLE t (c DATETIME DEFAULT CURRENT_TIMESTAMP)`, "c", true},
+		{"CURRENT_DATE", `CREATE TABLE t (c DATE DEFAULT CURRENT_DATE)`, "c", true},
+		{"CURRENT_TIME", `CREATE TABLE t (c TIME DEFAULT CURRENT_TIME)`, "c", true},
+		{"literal string", `CREATE TABLE t (c TEXT DEFAULT 'hello')`, "c", false},
+		{"literal number", `CREATE TABLE t (c INTEGER DEFAULT 42)`, "c", false},
+		{"no default", `CREATE TABLE t (c TEXT)`, "c", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := NewSchema()
+			err := schema.AddTable(tt.createSQL)
+			if err != nil {
+				t.Fatalf("AddTable failed: %v", err)
+			}
+
+			col := schema.Tables["t"].Columns[tt.colName]
+			if tt.wantNonDet {
+				if !col.HasDefault || col.DefaultIsDeterministic {
+					t.Errorf("expected non-deterministic DEFAULT, got HasDefault=%v, IsDet=%v",
+						col.HasDefault, col.DefaultIsDeterministic)
+				}
+			} else if col.HasDefault && !col.DefaultIsDeterministic {
+				t.Errorf("expected deterministic DEFAULT, got non-deterministic")
+			}
+		})
+	}
+}
+
+// TestSchema_TriggerVariants tests different trigger body contents
+func TestSchema_TriggerVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		triggerSQL     string
+		wantHasTrigger bool
+	}{
+		{
+			name: "random() in INSERT",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (id) VALUES (random()); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "datetime('now') in INSERT",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (id) VALUES (datetime('now')); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "CURRENT_TIMESTAMP in INSERT",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (id) VALUES (CURRENT_TIMESTAMP); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "literal only INSERT",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (id) VALUES (1); END`,
+			wantHasTrigger: false,
+		},
+		{
+			name: "UPDATE with column ref",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN UPDATE dst SET cnt = cnt + 1 WHERE id = 1; END`,
+			wantHasTrigger: true, // column ref in SET is non-det
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := NewSchema()
+			schema.AddTable(`CREATE TABLE src (id INTEGER)`)
+			schema.AddTable(`CREATE TABLE dst (id INTEGER, cnt INTEGER)`)
+			err := schema.AddTrigger(tt.triggerSQL)
+			if err != nil {
+				t.Fatalf("AddTrigger failed: %v", err)
+			}
+
+			table := schema.Tables["src"]
+			if table.HasTrigger != tt.wantHasTrigger {
+				t.Errorf("HasTrigger=%v, want %v", table.HasTrigger, tt.wantHasTrigger)
+			}
+		})
+	}
+}
+
+// TestCheckSQLWithSchema_CombinedDefaultAndTrigger tests table with both non-det DEFAULT and trigger
+func TestCheckSQLWithSchema_CombinedDefaultAndTrigger(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE combined (
+		id INTEGER PRIMARY KEY,
+		created DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`)
+	schema.AddTable(`CREATE TABLE combined_log (msg TEXT)`)
+	schema.AddTrigger(`CREATE TRIGGER combined_trigger AFTER INSERT ON combined
+		BEGIN INSERT INTO combined_log (msg) VALUES (random()); END`)
+
+	// Should fail for both reasons (trigger takes precedence in current impl)
+	result := CheckSQLWithSchema("INSERT INTO combined (id) VALUES (1)", schema)
+	if result.IsDeterministic {
+		t.Errorf("should be non-deterministic, got deterministic")
+	}
+}
+
+// TestCheckSQLWithSchema_UpdateDeleteIgnoreDefault tests that UPDATE/DELETE don't care about DEFAULT
+func TestCheckSQLWithSchema_UpdateDeleteIgnoreDefault(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE t (
+		id INTEGER PRIMARY KEY,
+		created DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`)
+
+	// UPDATE doesn't use DEFAULT values
+	result := CheckSQLWithSchema("UPDATE t SET id = 2 WHERE id = 1", schema)
+	if !result.IsDeterministic {
+		t.Errorf("UPDATE should ignore DEFAULT, reason=%s", result.Reason)
+	}
+
+	// DELETE doesn't use DEFAULT values
+	result = CheckSQLWithSchema("DELETE FROM t WHERE id = 1", schema)
+	if !result.IsDeterministic {
+		t.Errorf("DELETE should ignore DEFAULT, reason=%s", result.Reason)
+	}
+}
+
+// TestSchema_DefaultExpressionVariants tests various DEFAULT expression types
+func TestSchema_DefaultExpressionVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		createSQL  string
+		colName    string
+		wantNonDet bool
+	}{
+		// Non-deterministic DEFAULTs
+		{"CURRENT_TIMESTAMP", `CREATE TABLE t (c DATETIME DEFAULT CURRENT_TIMESTAMP)`, "c", true},
+		{"CURRENT_DATE", `CREATE TABLE t (c DATE DEFAULT CURRENT_DATE)`, "c", true},
+		{"CURRENT_TIME", `CREATE TABLE t (c TIME DEFAULT CURRENT_TIME)`, "c", true},
+		{"datetime('now')", `CREATE TABLE t (c DATETIME DEFAULT (datetime('now')))`, "c", true},
+		{"date('now')", `CREATE TABLE t (c DATE DEFAULT (date('now')))`, "c", true},
+		{"time('now')", `CREATE TABLE t (c TIME DEFAULT (time('now')))`, "c", true},
+		{"random()", `CREATE TABLE t (c INTEGER DEFAULT (random()))`, "c", true},
+		{"strftime with now", `CREATE TABLE t (c TEXT DEFAULT (strftime('%s', 'now')))`, "c", true},
+		{"julianday('now')", `CREATE TABLE t (c REAL DEFAULT (julianday('now')))`, "c", true},
+
+		// Deterministic DEFAULTs
+		{"literal string", `CREATE TABLE t (c TEXT DEFAULT 'hello')`, "c", false},
+		{"literal number", `CREATE TABLE t (c INTEGER DEFAULT 42)`, "c", false},
+		{"literal float", `CREATE TABLE t (c REAL DEFAULT 3.14)`, "c", false},
+		{"literal negative", `CREATE TABLE t (c INTEGER DEFAULT -1)`, "c", false},
+		{"NULL default", `CREATE TABLE t (c TEXT DEFAULT NULL)`, "c", false},
+		{"no default", `CREATE TABLE t (c TEXT)`, "c", false},
+		{"expression with literals", `CREATE TABLE t (c INTEGER DEFAULT (10 + 20))`, "c", false},
+		{"upper() on literal", `CREATE TABLE t (c TEXT DEFAULT (upper('test')))`, "c", false},
+		{"coalesce on literals", `CREATE TABLE t (c TEXT DEFAULT (coalesce(NULL, 'default')))`, "c", false},
+		{"abs on literal", `CREATE TABLE t (c INTEGER DEFAULT (abs(-42)))`, "c", false},
+		{"datetime fixed", `CREATE TABLE t (c DATETIME DEFAULT (datetime('2024-01-01')))`, "c", false},
+		{"strftime fixed", `CREATE TABLE t (c TEXT DEFAULT (strftime('%Y', '2024-01-01')))`, "c", false},
+
+		// Unknown function in DEFAULT (fail-safe to non-det)
+		{"unknown function", `CREATE TABLE t (c TEXT DEFAULT (custom_func()))`, "c", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := NewSchema()
+			err := schema.AddTable(tt.createSQL)
+			if err != nil {
+				t.Fatalf("AddTable failed: %v", err)
+			}
+
+			col := schema.Tables["t"].Columns[tt.colName]
+			if tt.wantNonDet {
+				if !col.HasDefault || col.DefaultIsDeterministic {
+					t.Errorf("expected non-deterministic DEFAULT, got HasDefault=%v, IsDet=%v",
+						col.HasDefault, col.DefaultIsDeterministic)
+				}
+			} else if col.HasDefault && !col.DefaultIsDeterministic {
+				t.Errorf("expected deterministic DEFAULT, got non-deterministic")
+			}
+		})
+	}
+}
+
+// TestSchema_TriggerBodyVariants tests various trigger body patterns
+func TestSchema_TriggerBodyVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		triggerSQL     string
+		wantHasTrigger bool
+	}{
+		// Non-deterministic triggers
+		{
+			name: "INSERT with random()",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (id) VALUES (random()); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with datetime('now')",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with date('now')",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (d) VALUES (date('now')); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with time('now')",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (tm) VALUES (time('now')); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with CURRENT_TIMESTAMP",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (ts) VALUES (CURRENT_TIMESTAMP); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with CURRENT_DATE",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (d) VALUES (CURRENT_DATE); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with CURRENT_TIME",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (tm) VALUES (CURRENT_TIME); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "UPDATE with column reference",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN UPDATE dst SET cnt = cnt + 1 WHERE id = 1; END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with last_insert_rowid()",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (ref) VALUES (last_insert_rowid()); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with changes()",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (n) VALUES (changes()); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT with randomblob()",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (data) VALUES (randomblob(16)); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "nested non-det in INSERT",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (h) VALUES (hex(random())); END`,
+			wantHasTrigger: true,
+		},
+		{
+			name: "INSERT SELECT (subquery)",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst SELECT * FROM other; END`,
+			wantHasTrigger: true,
+		},
+
+		// Deterministic triggers
+		{
+			name: "INSERT with literals only",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (id, data) VALUES (1, 'logged'); END`,
+			wantHasTrigger: false,
+		},
+		{
+			name: "INSERT with deterministic function",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (id, data) VALUES (1, upper('test')); END`,
+			wantHasTrigger: false,
+		},
+		{
+			name: "UPDATE with literal SET",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN UPDATE dst SET data = 'updated' WHERE id = 1; END`,
+			wantHasTrigger: false,
+		},
+		{
+			name: "DELETE with WHERE",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN DELETE FROM dst WHERE id = 1; END`,
+			wantHasTrigger: false,
+		},
+		{
+			name: "INSERT with fixed datetime",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('2024-01-01')); END`,
+			wantHasTrigger: false,
+		},
+		{
+			name: "INSERT with multiple literals",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (a, b, c) VALUES (1, 'two', 3.0); END`,
+			wantHasTrigger: false,
+		},
+		{
+			name: "INSERT with nested deterministic",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (s) VALUES (upper(lower('TEST'))); END`,
+			wantHasTrigger: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := NewSchema()
+			schema.AddTable(`CREATE TABLE src (id INTEGER)`)
+			schema.AddTable(`CREATE TABLE dst (id INTEGER, data TEXT, ts TEXT, d TEXT, tm TEXT, cnt INTEGER, ref INTEGER, n INTEGER, h TEXT, a INTEGER, b TEXT, c REAL, s TEXT)`)
+			err := schema.AddTrigger(tt.triggerSQL)
+			if err != nil {
+				t.Fatalf("AddTrigger failed: %v", err)
+			}
+
+			table := schema.Tables["src"]
+			if table.HasTrigger != tt.wantHasTrigger {
+				t.Errorf("HasTrigger=%v, want %v", table.HasTrigger, tt.wantHasTrigger)
+			}
+		})
+	}
+}
+
+// TestSchema_MultipleTriggerTypes tests different trigger event types
+func TestSchema_MultipleTriggerTypes(t *testing.T) {
+	t.Parallel()
+
+	triggerTypes := []struct {
+		name       string
+		triggerSQL string
+	}{
+		{
+			name: "BEFORE INSERT",
+			triggerSQL: `CREATE TRIGGER t BEFORE INSERT ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`,
+		},
+		{
+			name: "AFTER INSERT",
+			triggerSQL: `CREATE TRIGGER t AFTER INSERT ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`,
+		},
+		{
+			name: "BEFORE UPDATE",
+			triggerSQL: `CREATE TRIGGER t BEFORE UPDATE ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`,
+		},
+		{
+			name: "AFTER UPDATE",
+			triggerSQL: `CREATE TRIGGER t AFTER UPDATE ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`,
+		},
+		{
+			name: "BEFORE DELETE",
+			triggerSQL: `CREATE TRIGGER t BEFORE DELETE ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`,
+		},
+		{
+			name: "AFTER DELETE",
+			triggerSQL: `CREATE TRIGGER t AFTER DELETE ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`,
+		},
+		{
+			name: "INSTEAD OF INSERT (view trigger)",
+			triggerSQL: `CREATE TRIGGER t INSTEAD OF INSERT ON src
+				BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`,
+		},
+	}
+
+	for _, tt := range triggerTypes {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := NewSchema()
+			schema.AddTable(`CREATE TABLE src (id INTEGER)`)
+			schema.AddTable(`CREATE TABLE dst (ts TEXT)`)
+			err := schema.AddTrigger(tt.triggerSQL)
+			if err != nil {
+				t.Fatalf("AddTrigger failed: %v", err)
+			}
+
+			table := schema.Tables["src"]
+			if !table.HasTrigger {
+				t.Errorf("expected HasTrigger=true for %s", tt.name)
+			}
+		})
+	}
+}
+
+// TestSchema_DropTable tests the DropTable functionality
+func TestSchema_DropTable(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`)
+	schema.AddTable(`CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)`)
+
+	if _, ok := schema.Tables["users"]; !ok {
+		t.Fatal("users table should exist")
+	}
+	if _, ok := schema.Tables["orders"]; !ok {
+		t.Fatal("orders table should exist")
+	}
+
+	schema.DropTable("users")
+
+	if _, ok := schema.Tables["users"]; ok {
+		t.Error("users table should have been dropped")
+	}
+	if _, ok := schema.Tables["orders"]; !ok {
+		t.Error("orders table should still exist")
+	}
+
+	// Drop non-existent table should not panic
+	schema.DropTable("nonexistent")
+}
+
+// TestSchema_CaseInsensitivity tests that table/column names are case insensitive
+func TestSchema_CaseInsensitivity(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE Users (ID INTEGER PRIMARY KEY, Name TEXT DEFAULT 'default')`)
+
+	// Should be stored lowercase
+	if _, ok := schema.Tables["users"]; !ok {
+		t.Error("table should be stored as lowercase")
+	}
+	if _, ok := schema.Tables["Users"]; ok {
+		t.Error("table should not be stored with original case")
+	}
+
+	table := schema.Tables["users"]
+	if _, ok := table.Columns["id"]; !ok {
+		t.Error("column ID should be stored as lowercase 'id'")
+	}
+	if _, ok := table.Columns["name"]; !ok {
+		t.Error("column Name should be stored as lowercase 'name'")
+	}
+}
+
+// TestCheckSQLWithSchema_InsertColumnsVariants tests INSERT with various column specifications
+func TestCheckSQLWithSchema_InsertColumnsVariants(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE t (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		created DATETIME DEFAULT CURRENT_TIMESTAMP,
+		status TEXT DEFAULT 'active',
+		data BLOB
+	)`)
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantDet bool
+	}{
+		// Non-deterministic (missing column with non-det DEFAULT)
+		{
+			name:    "missing non-det DEFAULT column",
+			sql:     "INSERT INTO t (id, name, status, data) VALUES (1, 'test', 'active', NULL)",
+			wantDet: false,
+		},
+		{
+			name:    "only id specified",
+			sql:     "INSERT INTO t (id) VALUES (1)",
+			wantDet: false,
+		},
+		{
+			name:    "id and name only",
+			sql:     "INSERT INTO t (id, name) VALUES (1, 'test')",
+			wantDet: false,
+		},
+
+		// Deterministic
+		{
+			name:    "all columns specified including created",
+			sql:     "INSERT INTO t (id, name, created, status, data) VALUES (1, 'test', '2024-01-01', 'new', NULL)",
+			wantDet: true,
+		},
+		{
+			name:    "skip det DEFAULT column",
+			sql:     "INSERT INTO t (id, name, created, data) VALUES (1, 'test', '2024-01-01', NULL)",
+			wantDet: true,
+		},
+		{
+			name:    "id and created only",
+			sql:     "INSERT INTO t (id, created) VALUES (1, '2024-01-01')",
+			wantDet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQLWithSchema(tt.sql, schema)
+			if result.IsDeterministic != tt.wantDet {
+				t.Errorf("got IsDeterministic=%v, want %v, reason=%s",
+					result.IsDeterministic, tt.wantDet, result.Reason)
+			}
+		})
+	}
+}
+
+// TestCheckSQLWithSchema_TriggerOnDifferentOperations tests triggers for INSERT/UPDATE/DELETE
+func TestCheckSQLWithSchema_TriggerOnDifferentOperations(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE data (id INTEGER, value TEXT)`)
+	schema.AddTable(`CREATE TABLE audit (ts TEXT)`)
+	schema.AddTrigger(`CREATE TRIGGER audit_insert AFTER INSERT ON data
+		BEGIN INSERT INTO audit (ts) VALUES (datetime('now')); END`)
+	schema.AddTrigger(`CREATE TRIGGER audit_update AFTER UPDATE ON data
+		BEGIN INSERT INTO audit (ts) VALUES (datetime('now')); END`)
+	schema.AddTrigger(`CREATE TRIGGER audit_delete AFTER DELETE ON data
+		BEGIN INSERT INTO audit (ts) VALUES (datetime('now')); END`)
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantDet bool
+	}{
+		{"INSERT triggers non-det", "INSERT INTO data (id, value) VALUES (1, 'test')", false},
+		{"UPDATE triggers non-det", "UPDATE data SET value = 'new' WHERE id = 1", false},
+		{"DELETE triggers non-det", "DELETE FROM data WHERE id = 1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQLWithSchema(tt.sql, schema)
+			if result.IsDeterministic != tt.wantDet {
+				t.Errorf("got IsDeterministic=%v, want %v, reason=%s",
+					result.IsDeterministic, tt.wantDet, result.Reason)
+			}
+		})
+	}
+}
+
+// TestCheckSQLWithSchema_CombinedChecks tests that basic checks still work with schema
+func TestCheckSQLWithSchema_CombinedChecks(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE simple (id INTEGER, data TEXT)`)
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantDet bool
+		reason  string
+	}{
+		// Basic non-determinism should still be detected
+		{"random() still detected", "INSERT INTO simple (id, data) VALUES (random(), 'test')", false, "random"},
+		{"datetime('now') still detected", "INSERT INTO simple (id, data) VALUES (1, datetime('now'))", false, "datetime"},
+		{"CURRENT_TIMESTAMP still detected", "INSERT INTO simple (id, data) VALUES (1, CURRENT_TIMESTAMP)", false, "identifier"},
+		{"column ref still detected", "UPDATE simple SET data = id WHERE id = 1", false, "column reference"},
+		{"subquery still detected", "INSERT INTO simple SELECT * FROM other", false, "subquery"},
+
+		// Deterministic should pass
+		{"literal INSERT passes", "INSERT INTO simple (id, data) VALUES (1, 'test')", true, ""},
+		{"literal UPDATE passes", "UPDATE simple SET data = 'new' WHERE id = 1", true, ""},
+		{"literal DELETE passes", "DELETE FROM simple WHERE id = 1", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSQLWithSchema(tt.sql, schema)
+			if result.IsDeterministic != tt.wantDet {
+				t.Errorf("got IsDeterministic=%v, want %v, reason=%s",
+					result.IsDeterministic, tt.wantDet, result.Reason)
+			}
+		})
+	}
+}
+
+// TestCheckStatementWithSchema tests the parsed statement version
+func TestCheckStatementWithSchema(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE events (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		created DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`)
+
+	t.Run("parsed statement with non-det DEFAULT", func(t *testing.T) {
+		parser := sql.NewParser(strings.NewReader("INSERT INTO events (id, name) VALUES (1, 'test')"))
+		stmt, err := parser.ParseStatement()
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+
+		result := CheckStatementWithSchema(stmt, schema)
+		if result.IsDeterministic {
+			t.Error("expected non-deterministic due to missing created column")
+		}
+	})
+
+	t.Run("parsed statement with all columns", func(t *testing.T) {
+		parser := sql.NewParser(strings.NewReader("INSERT INTO events (id, name, created) VALUES (1, 'test', '2024-01-01')"))
+		stmt, err := parser.ParseStatement()
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+
+		result := CheckStatementWithSchema(stmt, schema)
+		if !result.IsDeterministic {
+			t.Errorf("expected deterministic, reason=%s", result.Reason)
+		}
+	})
+
+	t.Run("nil schema passes through", func(t *testing.T) {
+		parser := sql.NewParser(strings.NewReader("INSERT INTO events (id, name) VALUES (1, 'test')"))
+		stmt, err := parser.ParseStatement()
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+
+		result := CheckStatementWithSchema(stmt, nil)
+		if !result.IsDeterministic {
+			t.Error("nil schema should pass through basic check")
+		}
+	})
+}
+
+// TestSchema_AddTablePreservesTrigger tests that adding table preserves existing trigger info
+func TestSchema_AddTablePreservesTrigger(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+
+	// Add trigger first (table doesn't exist yet)
+	schema.AddTrigger(`CREATE TRIGGER t AFTER INSERT ON src
+		BEGIN INSERT INTO dst (ts) VALUES (datetime('now')); END`)
+
+	// Now add the table
+	schema.AddTable(`CREATE TABLE src (id INTEGER, name TEXT)`)
+
+	// Trigger flag should be preserved
+	table := schema.Tables["src"]
+	if !table.HasTrigger {
+		t.Error("HasTrigger should be preserved after AddTable")
+	}
+
+	// Column info should also be available
+	if _, ok := table.Columns["id"]; !ok {
+		t.Error("column info should be available")
+	}
+}
+
+// TestSchema_MultipleColumns tests table with many column types
+func TestSchema_MultipleColumns(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	err := schema.AddTable(`CREATE TABLE complex (
+		id INTEGER PRIMARY KEY,
+		name TEXT NOT NULL,
+		email TEXT UNIQUE,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		deleted_at DATETIME,
+		status TEXT DEFAULT 'active',
+		priority INTEGER DEFAULT 0,
+		score REAL DEFAULT 0.0,
+		data BLOB,
+		token TEXT DEFAULT (hex(randomblob(16))),
+		hash TEXT DEFAULT (upper('default'))
+	)`)
+	if err != nil {
+		t.Fatalf("AddTable failed: %v", err)
+	}
+
+	table := schema.Tables["complex"]
+
+	// Check non-det defaults
+	nonDetCols := []string{"created_at", "updated_at", "token"}
+	for _, col := range nonDetCols {
+		c := table.Columns[col]
+		if c == nil {
+			t.Errorf("column %s not found", col)
+			continue
+		}
+		if !c.HasDefault || c.DefaultIsDeterministic {
+			t.Errorf("column %s should have non-det DEFAULT", col)
+		}
+	}
+
+	// Check det defaults
+	detCols := []string{"status", "priority", "score", "hash"}
+	for _, col := range detCols {
+		c := table.Columns[col]
+		if c == nil {
+			t.Errorf("column %s not found", col)
+			continue
+		}
+		if c.HasDefault && !c.DefaultIsDeterministic {
+			t.Errorf("column %s should have deterministic DEFAULT", col)
+		}
+	}
+
+	// Check no default columns
+	noDefaultCols := []string{"name", "email", "deleted_at", "data"}
+	for _, col := range noDefaultCols {
+		c := table.Columns[col]
+		if c == nil {
+			t.Errorf("column %s not found", col)
+			continue
+		}
+		if c.HasDefault {
+			t.Errorf("column %s should not have DEFAULT", col)
+		}
+	}
+}
+
+// TestSchema_NonTableStatements tests handling of non-CREATE TABLE statements
+func TestSchema_NonTableStatements(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+
+	// These should not cause errors but also not add tables
+	nonTableStmts := []string{
+		"INSERT INTO t (id) VALUES (1)",
+		"UPDATE t SET x = 1",
+		"DELETE FROM t",
+		"SELECT * FROM t",
+	}
+
+	for _, stmt := range nonTableStmts {
+		err := schema.AddTable(stmt)
+		if err != nil {
+			t.Errorf("AddTable(%q) should not error, got: %v", stmt, err)
+		}
+		if len(schema.Tables) != 0 {
+			t.Errorf("no tables should be added for %q", stmt)
+		}
+	}
+}
+
+// TestSchema_NonTriggerStatements tests handling of non-CREATE TRIGGER statements
+func TestSchema_NonTriggerStatements(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE t (id INTEGER)`)
+
+	// These should not cause errors
+	nonTriggerStmts := []string{
+		"INSERT INTO t (id) VALUES (1)",
+		"UPDATE t SET id = 1",
+		"DELETE FROM t",
+		"SELECT * FROM t",
+		"CREATE TABLE other (id INTEGER)",
+	}
+
+	for _, stmt := range nonTriggerStmts {
+		err := schema.AddTrigger(stmt)
+		if err != nil {
+			t.Errorf("AddTrigger(%q) should not error, got: %v", stmt, err)
+		}
+	}
+
+	// Table should not have trigger marked
+	if schema.Tables["t"].HasTrigger {
+		t.Error("HasTrigger should be false")
+	}
+}
+
+// TestCheckSQLWithSchema_MultipleNonDetReasons tests statements with multiple non-det sources
+func TestCheckSQLWithSchema_MultipleNonDetReasons(t *testing.T) {
+	t.Parallel()
+
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE t (
+		id INTEGER PRIMARY KEY,
+		ts DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`)
+	schema.AddTable(`CREATE TABLE log (ts TEXT)`)
+	schema.AddTrigger(`CREATE TRIGGER t_trigger AFTER INSERT ON t
+		BEGIN INSERT INTO log (ts) VALUES (datetime('now')); END`)
+
+	// This INSERT:
+	// 1. Missing ts column (non-det DEFAULT)
+	// 2. Has non-det trigger
+	// 3. Uses random() in value
+	result := CheckSQLWithSchema("INSERT INTO t (id) VALUES (1)", schema)
+	if result.IsDeterministic {
+		t.Error("expected non-deterministic")
+	}
+	// Should report trigger (first schema check)
+	if !strings.Contains(result.Reason, "trigger") {
+		t.Errorf("expected trigger reason, got: %s", result.Reason)
+	}
+}
+
+// BenchmarkCheckSQLWithSchema benchmarks schema-aware checking
+func BenchmarkCheckSQLWithSchema(b *testing.B) {
+	schema := NewSchema()
+	schema.AddTable(`CREATE TABLE events (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		created DATETIME DEFAULT CURRENT_TIMESTAMP,
+		status TEXT DEFAULT 'active'
+	)`)
+
+	sqls := []string{
+		"INSERT INTO events (id, name) VALUES (1, 'test')",
+		"INSERT INTO events (id, name, created, status) VALUES (1, 'test', '2024-01-01', 'new')",
+		"UPDATE events SET name = 'updated' WHERE id = 1",
+		"DELETE FROM events WHERE id = 1",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, sqlStr := range sqls {
+			CheckSQLWithSchema(sqlStr, schema)
+		}
+	}
+}
+
+// BenchmarkSchema_AddTable benchmarks table parsing
+func BenchmarkSchema_AddTable(b *testing.B) {
+	createSQL := `CREATE TABLE complex (
+		id INTEGER PRIMARY KEY,
+		name TEXT NOT NULL,
+		email TEXT UNIQUE,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		status TEXT DEFAULT 'active',
+		priority INTEGER DEFAULT 0,
+		score REAL DEFAULT 0.0,
+		data BLOB
+	)`
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		schema := NewSchema()
+		schema.AddTable(createSQL)
+	}
+}

--- a/protocol/query/transform/dual_table_test.go
+++ b/protocol/query/transform/dual_table_test.go
@@ -56,7 +56,7 @@ func TestDualTableRule_Transform(t *testing.T) {
 			name:         "SELECT 'test' AS value FROM dual",
 			input:        "SELECT 'test' AS value FROM dual",
 			wantModified: true,
-			wantSQL:      "SELECT 'test' as `value`",
+			wantSQL:      "SELECT 'test' as value",
 		},
 		{
 			name:         "SELECT * FROM users (not dual)",

--- a/protocol/query/transform/sqlite_serializer.go
+++ b/protocol/query/transform/sqlite_serializer.go
@@ -92,6 +92,26 @@ func (s *SQLiteSerializer) nodeFormatter(buf *sqlparser.TrackedBuffer, node sqlp
 		if n.OverClause != nil {
 			buf.WriteString(" OVER()")
 		}
+	case sqlparser.IdentifierCS:
+		// Output identifier without backticks - SQLite standard SQL doesn't need them
+		buf.WriteString(n.String())
+	case sqlparser.IdentifierCI:
+		// Output identifier without backticks - SQLite standard SQL doesn't need them
+		buf.WriteString(n.String())
+	case sqlparser.TableName:
+		// Output table name without backticks
+		if n.Qualifier.NotEmpty() {
+			buf.WriteString(n.Qualifier.String())
+			buf.WriteString(".")
+		}
+		buf.WriteString(n.Name.String())
+	case *sqlparser.ColName:
+		// Output column name without backticks
+		if n.Qualifier.NonEmpty() {
+			buf.WriteString(n.Qualifier.Name.String())
+			buf.WriteString(".")
+		}
+		buf.WriteString(n.Name.String())
 	case sqlparser.Values:
 		// Format VALUES with uppercase keyword
 		buf.WriteString("VALUES ")


### PR DESCRIPTION
Add schema-aware determinism detection for DML statements to identify queries that may cause data divergence in statement-based replication. Non-deterministic DML is logged at debug level to aid debugging while allowing CDC (row-based) replication to handle these cases.

## Determinism Detection (`protocol/determinism/`)

New package for analyzing SQL statements:

- **detector.go**: Core detection logic using rqlite/sql parser
  - Detects non-deterministic functions: random(), randomblob(), datetime('now'), time('now'), julianday('now'), etc.
  - Detects non-deterministic identifiers: CURRENT_TIMESTAMP, CURRENT_DATE, CURRENT_TIME, rowid, _rowid_, oid
  - Detects unsafe patterns: DELETE with LIMIT but no ORDER BY, column self-references in UPDATE SET clauses
  - Unknown functions fail-safe to non-deterministic

- **schema.go**: Schema-aware detection with LRU caching
  - Tracks tables with non-deterministic DEFAULT expressions
  - Tracks tables with non-deterministic triggers
  - XXH64-keyed LRU cache (1024 entries) avoids re-parsing CREATE TABLE/TRIGGER SQL on every query

## Schema Cache Extensions (`db/schema_cache.go`)

Extended TableSchema with fields for determinism checking:
- `CreateSQL`: Original CREATE TABLE statement from sqlite_master
- `Triggers`: CREATE TRIGGER statements affecting the table
- `BuildDeterminismSchema()`: Builds determinism.Schema from cache

## Transpiler Fix (`protocol/query/transform/sqlite_serializer.go`)

SQLiteSerializer now outputs identifiers without MySQL-style backticks:
- Added cases for IdentifierCS, IdentifierCI, TableName, ColName
- Enables rqlite/sql parser to parse transpiled SQL correctly

## Integration (`coordinator/handler.go`)

- `checkDeterminism()`: Checks DML before execution on primary node
- Logs non-deterministic queries at debug level with reason
- Does not reject queries - allows CDC to handle them

## Testing

- Comprehensive unit tests for all detection cases
- Schema-aware tests for DEFAULT and trigger detection
- Cache behavior tests ensuring proper isolation