### PR TITLE
Fix bug in handler for admin routes for remove and allow nodes.

### DIFF
--- a/admin/cluster.go
+++ b/admin/cluster.go
@@ -162,7 +162,7 @@ func (h *AdminHandlers) handleClusterReplication(w http.ResponseWriter, r *http.
 
 // handleClusterRemove handles POST /admin/cluster/remove/{node_id}
 func (h *AdminHandlers) handleClusterRemove(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/admin/cluster/remove/")
+	path := strings.TrimPrefix(r.URL.Path, "/cluster/remove/")
 	nodeID, err := parsePeerNodeID(path)
 	if err != nil {
 		writeErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -185,7 +185,7 @@ func (h *AdminHandlers) handleClusterRemove(w http.ResponseWriter, r *http.Reque
 
 // handleClusterAllow handles POST /admin/cluster/allow/{node_id}
 func (h *AdminHandlers) handleClusterAllow(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/admin/cluster/allow/")
+	path := strings.TrimPrefix(r.URL.Path, "/cluster/allow/")
 	nodeID, err := parsePeerNodeID(path)
 	if err != nil {
 		writeErrorResponse(w, http.StatusBadRequest, err.Error())


### PR DESCRIPTION
Corrected route prefix trimming in the cluster management handlers. 

The 'handleClusterRemove' and 'handleClusterAllow' handlers were failing to parse the node ID because they were expecting the full URL path including '/admin'. These routes are mounted using 'http.StripPrefix' in the main admin router, the incoming request path already has the '/admin' prefix removed. 

Updated the prefix trimming logic to correctly identify the node ID from the relative path provided to the handlers.