### PR TITLE
fix: validate DDL during PREPARE and restore schema versions on snapshot catch-up

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -41,18 +41,24 @@ func (c *ClusterConfiguration) GetShutdownGracePeriod() time.Duration {
 
 // ReplicationConfiguration controls replication behavior
 type ReplicationConfiguration struct {
-	DefaultWriteConsist       string `toml:"default_write_consistency"`
-	DefaultReadConsist        string `toml:"default_read_consistency"`
-	WriteTimeoutMS            int    `toml:"write_timeout_ms"`
-	ReadTimeoutMS             int    `toml:"read_timeout_ms"`
-	EnableAntiEntropy         bool   `toml:"enable_anti_entropy"`
-	AntiEntropyIntervalS      int    `toml:"anti_entropy_interval_seconds"`
-	GCIntervalS               int    `toml:"gc_interval_seconds"` // GC interval - MUST be >= anti_entropy_interval_seconds
-	DeltaSyncThresholdTxns    int    `toml:"delta_sync_threshold_transactions"`
-	DeltaSyncThresholdSeconds int    `toml:"delta_sync_threshold_seconds"`
-	GCMinRetentionHours       int    `toml:"gc_min_retention_hours"`
-	GCMaxRetentionHours       int    `toml:"gc_max_retention_hours"`
-	StreamChunkSizeKB         int    `toml:"stream_chunk_size_kb"` // Size in KB for streaming chunks (default: 1024 = 1MB)
+	DefaultWriteConsist string `toml:"default_write_consistency"`
+	DefaultReadConsist  string `toml:"default_read_consistency"`
+	WriteTimeoutMS      int    `toml:"write_timeout_ms"`
+	// DDLValidationTimeoutMS bounds PREPARE for transactions containing DDL.
+	// DDL validation executes the real statement in a rolled-back transaction
+	// so a participant can promise a valid COMMIT, which can take far longer
+	// than a DML write - so it is bounded separately from write_timeout_ms
+	// rather than sharing its deadline.
+	DDLValidationTimeoutMS    int  `toml:"ddl_validation_timeout_ms"`
+	ReadTimeoutMS             int  `toml:"read_timeout_ms"`
+	EnableAntiEntropy         bool `toml:"enable_anti_entropy"`
+	AntiEntropyIntervalS      int  `toml:"anti_entropy_interval_seconds"`
+	GCIntervalS               int  `toml:"gc_interval_seconds"` // GC interval - MUST be >= anti_entropy_interval_seconds
+	DeltaSyncThresholdTxns    int  `toml:"delta_sync_threshold_transactions"`
+	DeltaSyncThresholdSeconds int  `toml:"delta_sync_threshold_seconds"`
+	GCMinRetentionHours       int  `toml:"gc_min_retention_hours"`
+	GCMaxRetentionHours       int  `toml:"gc_max_retention_hours"`
+	StreamChunkSizeKB         int  `toml:"stream_chunk_size_kb"` // Size in KB for streaming chunks (default: 1024 = 1MB)
 }
 
 // MySQLConfiguration for MySQL wire protocol server
@@ -272,6 +278,7 @@ var Config = &Configuration{
 		DefaultWriteConsist:       "QUORUM",
 		DefaultReadConsist:        "LOCAL_ONE",
 		WriteTimeoutMS:            5000,
+		DDLValidationTimeoutMS:    60000,
 		ReadTimeoutMS:             2000,
 		EnableAntiEntropy:         true,
 		AntiEntropyIntervalS:      30,    // 30s - frequent watermark updates (was 60s, flipped for GC safety)

--- a/coordinator/errors.go
+++ b/coordinator/errors.go
@@ -39,6 +39,25 @@ func (e *LocalPrepareError) Error() string {
 	return e.Reason
 }
 
+// RemotePrepareRejectedError indicates prepare quorum was not achieved and at
+// least one remote participant explicitly rejected the transaction during
+// PREPARE (a deterministic "this can never apply here" verdict, for example
+// DDL SQLite cannot apply), rather than merely failing to respond in time.
+// Retrying cannot change that participant's verdict, so this replaces the
+// retryable QuorumNotAchievedError when a rejection is on record. A remote
+// rejection alone - with quorum otherwise achieved - never produces this
+// error; it carries no veto over cluster DDL.
+type RemotePrepareRejectedError struct {
+	NodeID uint64
+	Reason string
+}
+
+// Error reports the rejecting participant's own reason so clients receive the
+// actual SQL failure rather than 2PC internals.
+func (e *RemotePrepareRejectedError) Error() string {
+	return e.Reason
+}
+
 // CoordinatorNotParticipatedError indicates the coordinator failed to participate in the prepare phase
 type CoordinatorNotParticipatedError struct {
 	TxnID uint64

--- a/coordinator/errors.go
+++ b/coordinator/errors.go
@@ -27,13 +27,38 @@ func (e *QuorumNotAchievedError) Error() string {
 		e.Phase, e.AcksReceived, e.QuorumRequired, e.TotalMembership, e.AliveNodes)
 }
 
+// LocalPrepareError indicates this node explicitly rejected the transaction
+// during PREPARE, as opposed to failing to answer. The rejection is final for
+// this attempt, so the coordinator surfaces the participant's own reason instead
+// of the retry signal used for write-write conflicts.
+type LocalPrepareError struct {
+	Reason string
+}
+
+func (e *LocalPrepareError) Error() string {
+	return e.Reason
+}
+
 // CoordinatorNotParticipatedError indicates the coordinator failed to participate in the prepare phase
 type CoordinatorNotParticipatedError struct {
 	TxnID uint64
+	Err   error // Reason the local prepare failed, nil when it never responded
 }
 
+// Error reports the participant's own reason when it rejected the transaction so
+// clients receive the actual SQL failure rather than 2PC internals. The generic
+// message is only used when the local node never answered.
 func (e *CoordinatorNotParticipatedError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
 	return "coordinator must participate: local prepare failed"
+}
+
+// Unwrap exposes the underlying prepare failure so callers can map it to a
+// protocol-level error code.
+func (e *CoordinatorNotParticipatedError) Unwrap() error {
+	return e.Err
 }
 
 // PartialCommitError represents a partial commit where some nodes committed but quorum was not achieved
@@ -46,7 +71,7 @@ type PartialCommitError struct {
 
 func (e *PartialCommitError) Error() string {
 	if e.IsLocal {
-		return fmt.Sprintf("partial commit: local commit failed after remote quorum (bug in PREPARE): %v", e.LocalError)
+		return fmt.Sprintf("partial commit: local commit failed after remote quorum: %v", e.LocalError)
 	}
 	return fmt.Sprintf("partial commit: got %d remote commit acks, needed %d (some nodes may have committed)",
 		e.RemoteAcks, e.RemoteQuorumNeeded)

--- a/coordinator/errors_test.go
+++ b/coordinator/errors_test.go
@@ -213,7 +213,7 @@ func TestPartialCommitError(t *testing.T) {
 			remoteAcks:         0,
 			remoteQuorumNeeded: 0,
 			localError:         errors.New("database locked"),
-			expected:           "partial commit: local commit failed after remote quorum (bug in PREPARE): database locked",
+			expected:           "partial commit: local commit failed after remote quorum: database locked",
 		},
 		{
 			name:               "local commit failed with nil error",
@@ -221,7 +221,7 @@ func TestPartialCommitError(t *testing.T) {
 			remoteAcks:         0,
 			remoteQuorumNeeded: 0,
 			localError:         nil,
-			expected:           "partial commit: local commit failed after remote quorum (bug in PREPARE): <nil>",
+			expected:           "partial commit: local commit failed after remote quorum: <nil>",
 		},
 		{
 			name:               "local commit failed with wrapped error",
@@ -229,7 +229,7 @@ func TestPartialCommitError(t *testing.T) {
 			remoteAcks:         0,
 			remoteQuorumNeeded: 0,
 			localError:         errors.New("failed to acquire lock: timeout"),
-			expected:           "partial commit: local commit failed after remote quorum (bug in PREPARE): failed to acquire lock: timeout",
+			expected:           "partial commit: local commit failed after remote quorum: failed to acquire lock: timeout",
 		},
 		{
 			name:               "remote quorum failed with high numbers",

--- a/coordinator/full_replication_test.go
+++ b/coordinator/full_replication_test.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -604,9 +605,14 @@ func TestLocalPrepareMustSucceed(t *testing.T) {
 		t.Fatal("Expected write to fail when coordinator prepare fails, but it succeeded")
 	}
 
-	// Verify error message indicates coordinator must participate
-	if !contains(err.Error(), "coordinator must participate") {
-		t.Errorf("Expected 'coordinator must participate' error message, got: %v", err)
+	// Coordinator rejection must surface the participant's own reason so the
+	// client sees the real failure instead of 2PC internals
+	var notParticipated *CoordinatorNotParticipatedError
+	if !errors.As(err, &notParticipated) {
+		t.Errorf("Expected CoordinatorNotParticipatedError, got: %v", err)
+	}
+	if !contains(err.Error(), "local prepare failed") {
+		t.Errorf("Expected local prepare failure reason in error message, got: %v", err)
 	}
 
 	// Wait for abort goroutines to complete (abortTransaction spawns goroutines)

--- a/coordinator/handler.go
+++ b/coordinator/handler.go
@@ -153,6 +153,29 @@ func getWriteTimeout() time.Duration {
 	return 300 * time.Second
 }
 
+// getDDLValidationTimeout returns the configured DDL PREPARE validation
+// timeout, or the default (60s). PREPARE for a DDL statement executes the
+// real statement in a rolled-back transaction so a participant can promise a
+// valid COMMIT, which can take far longer than a DML write - so it is bounded
+// separately from write_timeout_ms, not by it.
+func getDDLValidationTimeout() time.Duration {
+	if cfg.Config != nil && cfg.Config.Replication.DDLValidationTimeoutMS > 0 {
+		return time.Duration(cfg.Config.Replication.DDLValidationTimeoutMS) * time.Millisecond
+	}
+	return 60 * time.Second
+}
+
+// writeTimeoutForStatements returns the deadline budget WriteTransaction needs
+// for this transaction: the DDL validation timeout if it carries any DDL
+// statement (PREPARE will execute-and-rollback the real statement for each
+// one), otherwise the regular write timeout.
+func writeTimeoutForStatements(stmts []protocol.Statement) time.Duration {
+	if txnHasDDL(stmts) {
+		return getDDLValidationTimeout()
+	}
+	return getWriteTimeout()
+}
+
 // NodeStatus enum
 type NodeStatus int32
 
@@ -630,7 +653,7 @@ func (h *CoordinatorHandler) handleMutation(stmt protocol.Statement, params []in
 		RequiredSchemaVersion: schemaVersion,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), getWriteTimeout())
+	ctx, cancel := context.WithTimeout(context.Background(), writeTimeoutForStatements(txn.Statements))
 	defer cancel()
 
 	// Cancel hook context when done (safe even if nil)
@@ -826,7 +849,7 @@ func (h *CoordinatorHandler) handleVectorControlMutation(
 		Database:              stmt.Database,
 		RequiredSchemaVersion: schemaVersion,
 	}
-	writeCtx, cancel := context.WithTimeout(context.Background(), getWriteTimeout())
+	writeCtx, cancel := context.WithTimeout(context.Background(), writeTimeoutForStatements(txn.Statements))
 	defer cancel()
 	if err := h.writeCoord.WriteTransaction(writeCtx, txn); err != nil {
 		return nil, err
@@ -1254,7 +1277,7 @@ func (h *CoordinatorHandler) handleCommit(session *protocol.ConnectionSession) (
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), getWriteTimeout())
+	ctx, cancel := context.WithTimeout(context.Background(), writeTimeoutForStatements(txn.Statements))
 	defer cancel()
 
 	err := h.writeCoord.WriteTransaction(ctx, txn)

--- a/coordinator/write_coordinator.go
+++ b/coordinator/write_coordinator.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -102,6 +103,10 @@ type ReplicationResponse struct {
 	// ConflictDetected indicates write-write conflict
 	ConflictDetected bool
 	ConflictDetails  string
+	// Rejected indicates the participant refused the statement itself (for example
+	// DDL SQLite cannot apply). Timeouts and storage failures leave it false so they
+	// stay retryable missing ACKs rather than a final verdict.
+	Rejected bool
 }
 
 // NewWriteCoordinator creates a new write coordinator for full database replication
@@ -325,15 +330,31 @@ func (wc *WriteCoordinator) runPreparePhase(ctx context.Context, txn *Transactio
 
 	// Execute prepare phase on all nodes (including self) - single attempt, no retry
 	// All nodes now participate uniformly - no skipLocalReplication
-	prepResponses, conflictErr := wc.executePreparePhase(ctx, txn, prepReq, otherNodes, false)
+	prepResponses, prepErr := wc.executePreparePhase(ctx, txn, prepReq, otherNodes, false)
 	telemetry.TwoPhaseQuorumAcks.With("prepare").Observe(float64(len(prepResponses)))
 
-	if conflictErr != nil {
+	// A local rejection (invalid DDL, missing table, ...) is final - surface the
+	// underlying reason so the client gets the matching protocol error instead of
+	// a retry signal.
+	var localPrepareErr *LocalPrepareError
+	if errors.As(prepErr, &localPrepareErr) {
+		// Logged above Debug because the error returned to the client carries only
+		// the statement-level reason: this is where txn_id and reason are tied
+		// together for operators. Rejections are rare, so this is not a hot path.
+		log.Warn().
+			Uint64("txn_id", txn.ID).
+			Str("reason", localPrepareErr.Reason).
+			Msg("Local PREPARE rejected transaction - aborting")
+
+		return nil, &CoordinatorNotParticipatedError{TxnID: txn.ID, Err: localPrepareErr}
+	}
+
+	if prepErr != nil {
 		// Write-write conflict detected - abort and signal client to retry
 		telemetry.WriteConflictsTotal.With("intent", "slow").Inc()
 		log.Debug().
 			Uint64("txn_id", txn.ID).
-			Err(conflictErr).
+			Err(prepErr).
 			Msg("Conflict detected - aborting transaction, client should retry")
 		// Return MySQL 1213 (ER_LOCK_DEADLOCK) - standard signal for client retry
 		return nil, protocol.ErrDeadlock()
@@ -493,11 +514,17 @@ func (wc *WriteCoordinator) commitLocalAfterRemoteQuorum(ctx context.Context, re
 			Err(localErr).
 			Str("resp_error", errMsg).
 			Uint64("txn_id", txnID).
-			Msg("CRITICAL: Local commit failed after remote quorum achieved - this indicates a bug in PREPARE")
+			Msg("CRITICAL: Local commit failed after remote quorum achieved - node has diverged from the committed quorum")
 		// CRITICAL: Don't abort remotes - they already committed. Return error but data is partially committed.
+		// Prefer the participant's reported error: a failed COMMIT response carries
+		// the reason in localResp.Error while localErr stays nil.
+		reportedErr := localErr
+		if reportedErr == nil && errMsg != "" {
+			reportedErr = errors.New(errMsg)
+		}
 		return nil, &PartialCommitError{
 			IsLocal:    true,
-			LocalError: localErr,
+			LocalError: reportedErr,
 		}
 	}
 
@@ -647,25 +674,32 @@ func (wc *WriteCoordinator) executePreparePhase(ctx context.Context, txn *Transa
 	// Channel for collecting responses
 	prepChan := make(chan response, totalNodes)
 
+	// Every PREPARE call is bounded by the same timeout the collector gives up
+	// after. Without it an abandoned call can still durably prepare a transaction
+	// the coordinator has already stopped tracking. PREPARE does real work -
+	// persisting intents and validating DDL - so this window is not theoretical.
+	dispatch := func(nodeID uint64, replicator Replicator) {
+		prepCtx, cancel := context.WithTimeout(ctx, wc.timeout)
+		defer cancel()
+
+		resp, err := replicator.ReplicateTransaction(prepCtx, nodeID, prepReq)
+		prepChan <- response{nodeID: nodeID, resp: resp, err: err}
+	}
+
 	// Send to other nodes
 	for _, nodeID := range otherNodes {
-		go func(nid uint64) {
-			resp, err := wc.replicator.ReplicateTransaction(ctx, nid, prepReq)
-			prepChan <- response{nodeID: nid, resp: resp, err: err}
-		}(nodeID)
+		go dispatch(nodeID, wc.replicator)
 	}
 
 	// Send to self if not skipped
 	if !skipLocalReplication {
-		go func() {
-			resp, err := wc.localReplicator.ReplicateTransaction(ctx, wc.nodeID, prepReq)
-			prepChan <- response{nodeID: wc.nodeID, resp: resp, err: err}
-		}()
+		go dispatch(wc.nodeID, wc.localReplicator)
 	}
 
 	// Collect responses
 	prepResponses := make(map[uint64]*ReplicationResponse)
 	var conflictErr error
+	var localErr error
 
 	for i := 0; i < totalNodes; i++ {
 		select {
@@ -699,12 +733,30 @@ func (wc *WriteCoordinator) executePreparePhase(ctx context.Context, txn *Transa
 					Uint64("node_id", r.nodeID).
 					Str("error", r.resp.Error).
 					Msg("Prepare returned failure")
+				// Only an explicit rejection is a final answer. Anything else - a
+				// timeout, a storage error - must fall through to the quorum check so
+				// it stays retryable, exactly as before DDL was validated here.
+				if r.nodeID == wc.nodeID && r.resp.Rejected {
+					reason := r.resp.Error
+					if reason == "" {
+						reason = "local prepare rejected the transaction"
+					}
+					localErr = &LocalPrepareError{Reason: reason}
+				}
 			}
 		case <-time.After(wc.timeout):
 			log.Warn().
 				Uint64("txn_id", txn.ID).
 				Msg("Prepare phase timeout waiting for responses")
 		}
+	}
+
+	// An explicit local rejection is deterministic, so it takes precedence over a
+	// peer conflict: retrying the transaction cannot make it succeed. Transport
+	// failures and missing responses are not rejections - they fall through to the
+	// quorum check.
+	if localErr != nil {
+		return prepResponses, localErr
 	}
 
 	// If any conflict was detected, return the error

--- a/coordinator/write_coordinator.go
+++ b/coordinator/write_coordinator.go
@@ -312,6 +312,19 @@ func isDMLStatement(stmtType protocol.StatementCode) bool {
 	}
 }
 
+// txnHasDDL reports whether any statement is DDL. PREPARE validates DDL by
+// executing the real statement in a rolled-back transaction, which can take
+// far longer than a DML write, so a transaction carrying DDL needs the DDL
+// validation timeout rather than the regular write timeout.
+func txnHasDDL(stmts []protocol.Statement) bool {
+	for _, stmt := range stmts {
+		if stmt.Type == protocol.StatementDDL {
+			return true
+		}
+	}
+	return false
+}
+
 // estimateCDCPayloadSize estimates the CDC payload size for a transaction.
 // Used to decide between regular RPC and streaming for large payloads.
 func estimateCDCPayloadSize(statements []protocol.Statement) int {
@@ -330,7 +343,7 @@ func (wc *WriteCoordinator) runPreparePhase(ctx context.Context, txn *Transactio
 
 	// Execute prepare phase on all nodes (including self) - single attempt, no retry
 	// All nodes now participate uniformly - no skipLocalReplication
-	prepResponses, prepErr := wc.executePreparePhase(ctx, txn, prepReq, otherNodes, false)
+	prepResponses, remoteRejection, prepErr := wc.executePreparePhase(ctx, txn, prepReq, otherNodes, false)
 	telemetry.TwoPhaseQuorumAcks.With("prepare").Observe(float64(len(prepResponses)))
 
 	// A local rejection (invalid DDL, missing table, ...) is final - surface the
@@ -363,6 +376,23 @@ func (wc *WriteCoordinator) runPreparePhase(ctx context.Context, txn *Transactio
 	// Check if quorum was achieved
 	totalAcks := len(prepResponses)
 	if totalAcks < cluster.RequiredQuorum {
+		// A remote rejection carries no veto on its own - it only replaces the
+		// retry signal once quorum has separately failed to form. Retrying a
+		// transaction one participant deterministically refused cannot succeed,
+		// so surface that participant's own reason instead of a generic
+		// quorum-not-achieved error the client would otherwise retry forever.
+		if remoteRejection != nil {
+			log.Warn().
+				Uint64("txn_id", txn.ID).
+				Uint64("node_id", remoteRejection.NodeID).
+				Str("reason", remoteRejection.Reason).
+				Int("total_acks", totalAcks).
+				Int("required_quorum", cluster.RequiredQuorum).
+				Msg("Prepare quorum not achieved and a remote participant rejected the transaction - aborting")
+
+			return nil, remoteRejection
+		}
+
 		log.Warn().
 			Uint64("txn_id", txn.ID).
 			Int("total_acks", totalAcks).
@@ -399,7 +429,11 @@ func (wc *WriteCoordinator) runPreparePhase(ctx context.Context, txn *Transactio
 
 // sendRemoteCommits launches goroutines to send commit requests to remote nodes.
 // Uses streaming for large payloads (≥128KB) if the replicator supports it.
-func (wc *WriteCoordinator) sendRemoteCommits(_ context.Context, preparedNodes map[uint64]*ReplicationResponse, req *ReplicationRequest, txnID uint64) chan response {
+// commitTimeout bounds each remote COMMIT RPC; the caller (runCommitPhase)
+// decides its value from the transaction's statements so a DDL COMMIT gets
+// the same DDL-aware budget PREPARE was given, instead of the fixed regular
+// write timeout.
+func (wc *WriteCoordinator) sendRemoteCommits(_ context.Context, preparedNodes map[uint64]*ReplicationResponse, req *ReplicationRequest, txnID uint64, commitTimeout time.Duration) chan response {
 	// Count other prepared nodes (excluding self)
 	otherPreparedNodes := 0
 	for nodeID := range preparedNodes {
@@ -433,8 +467,11 @@ func (wc *WriteCoordinator) sendRemoteCommits(_ context.Context, preparedNodes m
 			Uint64("target_node", nodeID).
 			Msg("sending COMMIT to remote node")
 		go func(nid uint64) {
-			// Use detached context - remote commits should complete even if parent cancelled
-			commitCtx, commitCancel := context.WithTimeout(context.Background(), wc.timeout)
+			// Use detached context - remote commits should complete even if parent cancelled.
+			// Bounded by commitTimeout (not wc.timeout): the remote already promised at
+			// PREPARE it can commit, and for a DDL transaction that can take far longer
+			// than the regular write timeout.
+			commitCtx, commitCancel := context.WithTimeout(context.Background(), commitTimeout)
 			defer commitCancel()
 
 			var resp *ReplicationResponse
@@ -451,8 +488,11 @@ func (wc *WriteCoordinator) sendRemoteCommits(_ context.Context, preparedNodes m
 	return commitChan
 }
 
-// waitForRemoteQuorum collects remote commit responses until quorum is achieved or timeout
-func (wc *WriteCoordinator) waitForRemoteQuorum(commitChan chan response, otherPreparedNodes int, remoteQuorumNeeded int, txnID uint64) (map[uint64]*ReplicationResponse, int) {
+// waitForRemoteQuorum collects remote commit responses until quorum is achieved or timeout.
+// commitTimeout must match the budget sendRemoteCommits gave each remote RPC:
+// this collector gives up on a per-response basis with the same bound, so a
+// mismatch here would abandon a response sendRemoteCommits is still waiting on.
+func (wc *WriteCoordinator) waitForRemoteQuorum(commitChan chan response, otherPreparedNodes int, remoteQuorumNeeded int, txnID uint64, commitTimeout time.Duration) (map[uint64]*ReplicationResponse, int) {
 	commitResponses := make(map[uint64]*ReplicationResponse)
 
 	// STEP 2: Collect remote commit responses until we have enough for quorum
@@ -476,7 +516,7 @@ func (wc *WriteCoordinator) waitForRemoteQuorum(commitChan chan response, otherP
 				}
 				log.Error().Err(r.err).Uint64("node_id", r.nodeID).Str("resp_error", errMsg).Msg("Remote commit failed")
 			}
-		case <-time.After(wc.timeout):
+		case <-time.After(commitTimeout):
 			log.Warn().
 				Uint64("txn_id", txnID).
 				Int("remote_acks", remoteAcks).
@@ -558,11 +598,18 @@ func (wc *WriteCoordinator) runCommitPhase(ctx context.Context, txn *Transaction
 	// Note: selfPrepared is guaranteed to be true at this point (checked above)
 	remoteQuorumNeeded := cluster.RequiredQuorum - 1 // We'll add local commit after
 
+	// A transaction carrying DDL needs the same DDL-aware budget for COMMIT
+	// that PREPARE was given: a participant that ACKed PREPARE promised it can
+	// COMMIT, and applying DDL can take far longer than the regular write
+	// timeout. Using the same writeTimeoutForStatements source of truth as
+	// PREPARE keeps both phases consistent for a given transaction.
+	commitTimeout := writeTimeoutForStatements(txn.Statements)
+
 	// Send commit requests to remote nodes
-	commitChan := wc.sendRemoteCommits(ctx, prepResponses, commitReq, txn.ID)
+	commitChan := wc.sendRemoteCommits(ctx, prepResponses, commitReq, txn.ID, commitTimeout)
 
 	// Wait for remote quorum
-	commitResponses, remoteAcks := wc.waitForRemoteQuorum(commitChan, otherPreparedNodes, remoteQuorumNeeded, txn.ID)
+	commitResponses, remoteAcks := wc.waitForRemoteQuorum(commitChan, otherPreparedNodes, remoteQuorumNeeded, txn.ID, commitTimeout)
 
 	// STEP 3: Check if we got enough remote ACKs
 	if remoteAcks < remoteQuorumNeeded {
@@ -655,9 +702,12 @@ type response struct {
 }
 
 // executePreparePhase broadcasts prepare requests to all nodes and collects responses.
-// Returns successful responses and a conflict error if any node reports a conflict.
+// Returns successful responses, the first remote (non-local) explicit rejection seen (if
+// any - the caller decides whether it matters, since a remote rejection alone must not
+// veto a transaction that otherwise reaches quorum), and a conflict error if any node
+// reports a conflict.
 func (wc *WriteCoordinator) executePreparePhase(ctx context.Context, txn *Transaction, prepReq *ReplicationRequest,
-	otherNodes []uint64, skipLocalReplication bool) (map[uint64]*ReplicationResponse, error) {
+	otherNodes []uint64, skipLocalReplication bool) (map[uint64]*ReplicationResponse, *RemotePrepareRejectedError, error) {
 
 	// Calculate total nodes to contact
 	totalNodes := len(otherNodes)
@@ -668,18 +718,28 @@ func (wc *WriteCoordinator) executePreparePhase(ctx context.Context, txn *Transa
 	if totalNodes == 0 {
 		// No nodes to contact - this is OK if local execution was already done
 		// Return empty map, caller will add self if skipLocalReplication was true
-		return make(map[uint64]*ReplicationResponse), nil
+		return make(map[uint64]*ReplicationResponse), nil, nil
 	}
 
 	// Channel for collecting responses
 	prepChan := make(chan response, totalNodes)
+
+	// A transaction carrying DDL needs the DDL validation timeout here, not the
+	// regular write timeout: PREPARE executes the real statement in a
+	// rolled-back transaction on every participant, including remote nodes -
+	// the deadline set on prepCtx below propagates over gRPC as the incoming
+	// context each participant validates under.
+	prepTimeout := wc.timeout
+	if txnHasDDL(txn.Statements) {
+		prepTimeout = getDDLValidationTimeout()
+	}
 
 	// Every PREPARE call is bounded by the same timeout the collector gives up
 	// after. Without it an abandoned call can still durably prepare a transaction
 	// the coordinator has already stopped tracking. PREPARE does real work -
 	// persisting intents and validating DDL - so this window is not theoretical.
 	dispatch := func(nodeID uint64, replicator Replicator) {
-		prepCtx, cancel := context.WithTimeout(ctx, wc.timeout)
+		prepCtx, cancel := context.WithTimeout(ctx, prepTimeout)
 		defer cancel()
 
 		resp, err := replicator.ReplicateTransaction(prepCtx, nodeID, prepReq)
@@ -700,6 +760,7 @@ func (wc *WriteCoordinator) executePreparePhase(ctx context.Context, txn *Transa
 	prepResponses := make(map[uint64]*ReplicationResponse)
 	var conflictErr error
 	var localErr error
+	var remoteRejection *RemotePrepareRejectedError
 
 	for i := 0; i < totalNodes; i++ {
 		select {
@@ -736,15 +797,25 @@ func (wc *WriteCoordinator) executePreparePhase(ctx context.Context, txn *Transa
 				// Only an explicit rejection is a final answer. Anything else - a
 				// timeout, a storage error - must fall through to the quorum check so
 				// it stays retryable, exactly as before DDL was validated here.
-				if r.nodeID == wc.nodeID && r.resp.Rejected {
+				if r.resp.Rejected {
 					reason := r.resp.Error
-					if reason == "" {
-						reason = "local prepare rejected the transaction"
+					if r.nodeID == wc.nodeID {
+						if reason == "" {
+							reason = "local prepare rejected the transaction"
+						}
+						localErr = &LocalPrepareError{Reason: reason}
+					} else if remoteRejection == nil {
+						// A remote rejection does not by itself abort the transaction -
+						// it has no veto over quorum. It is only surfaced by the caller
+						// as a final answer if quorum also fails to form.
+						if reason == "" {
+							reason = "remote prepare rejected the transaction"
+						}
+						remoteRejection = &RemotePrepareRejectedError{NodeID: r.nodeID, Reason: reason}
 					}
-					localErr = &LocalPrepareError{Reason: reason}
 				}
 			}
-		case <-time.After(wc.timeout):
+		case <-time.After(prepTimeout):
 			log.Warn().
 				Uint64("txn_id", txn.ID).
 				Msg("Prepare phase timeout waiting for responses")
@@ -756,13 +827,13 @@ func (wc *WriteCoordinator) executePreparePhase(ctx context.Context, txn *Transa
 	// failures and missing responses are not rejections - they fall through to the
 	// quorum check.
 	if localErr != nil {
-		return prepResponses, localErr
+		return prepResponses, remoteRejection, localErr
 	}
 
 	// If any conflict was detected, return the error
 	if conflictErr != nil {
-		return prepResponses, conflictErr
+		return prepResponses, remoteRejection, conflictErr
 	}
 
-	return prepResponses, nil
+	return prepResponses, remoteRejection, nil
 }

--- a/coordinator/write_coordinator_benchmarks_test.go
+++ b/coordinator/write_coordinator_benchmarks_test.go
@@ -66,7 +66,7 @@ func BenchmarkExecutePreparePhase(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+		_, _, _ = wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 	}
 }
 
@@ -94,7 +94,7 @@ func BenchmarkWaitForRemoteQuorum(b *testing.B) {
 		close(commitChan)
 		b.StartTimer()
 
-		_, _ = wc.waitForRemoteQuorum(commitChan, numResponses, quorumNeeded, 1)
+		_, _ = wc.waitForRemoteQuorum(commitChan, numResponses, quorumNeeded, 1, wc.timeout)
 	}
 }
 

--- a/coordinator/write_coordinator_commit_ddl_timeout_test.go
+++ b/coordinator/write_coordinator_commit_ddl_timeout_test.go
@@ -1,0 +1,167 @@
+package coordinator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maxpert/marmot/cfg"
+)
+
+// =============================================================================
+// COMMIT-phase DDL-aware timeout tests.
+//
+// PREPARE for a transaction carrying DDL is bounded by the DDL validation
+// timeout (getDDLValidationTimeout), not the regular write timeout, because
+// PREPARE executes the real statement in a rolled-back transaction. A
+// participant that ACKs PREPARE has promised it can COMMIT - so COMMIT must
+// give that same participant at least as much time to actually apply the
+// statement. These tests prove the COMMIT-phase remote RPC bound and the
+// commit-response collector bound both follow the same DDL-aware budget as
+// PREPARE, not the fixed regular write timeout (wc.timeout).
+// =============================================================================
+
+// TestSendRemoteCommits_UsesProvidedCommitTimeoutNotCoordinatorTimeout proves
+// sendRemoteCommits bounds each remote COMMIT RPC using the commitTimeout
+// explicitly passed by the caller, not wc.timeout. runCommitPhase is the
+// caller that decides the DDL-aware budget; sendRemoteCommits must honor
+// whatever it is given.
+func TestSendRemoteCommits_UsesProvidedCommitTimeoutNotCoordinatorTimeout(t *testing.T) {
+	defer CheckGoroutines(t)()
+	InitTestTelemetry()
+
+	recorder := &deadlineRecordingReplicator{}
+	wc := &WriteCoordinator{
+		nodeID:     1,
+		replicator: recorder,
+		// wc.timeout is deliberately tiny - the commit call must NOT be bounded by it.
+		timeout: 10 * time.Millisecond,
+	}
+
+	preparedNodes := map[uint64]*ReplicationResponse{
+		1: CreateSuccessResponse(), // coordinator, excluded from remote commits
+		2: CreateSuccessResponse(),
+		3: CreateSuccessResponse(),
+	}
+	req := &ReplicationRequest{TxnID: 900, Phase: PhaseCommit}
+
+	commitTimeout := 2 * time.Second
+	start := time.Now()
+	commitChan := wc.sendRemoteCommits(context.Background(), preparedNodes, req, 900, commitTimeout)
+
+	// Drain the channel so goroutines complete before CheckGoroutines runs.
+	for i := 0; i < 2; i++ {
+		<-commitChan
+	}
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	if len(recorder.deadlines) != 2 {
+		t.Fatalf("recorded deadlines: got %d, want 2", len(recorder.deadlines))
+	}
+	for i, deadline := range recorder.deadlines {
+		budget := deadline.Sub(start)
+		// A wide margin above wc.timeout (10ms) is required - not just
+		// "greater than" - since scheduling jitter alone can push the recorded
+		// budget past wc.timeout even when commitTimeout was NOT applied.
+		if budget < 500*time.Millisecond {
+			t.Errorf("call %d deadline budget %v is not comfortably above wc.timeout (%v) - commitTimeout was not applied", i, budget, wc.timeout)
+		}
+		if budget > commitTimeout+200*time.Millisecond {
+			t.Errorf("call %d deadline budget %v exceeds the provided commitTimeout (%v)", i, budget, commitTimeout)
+		}
+	}
+}
+
+// TestRunCommitPhase_DDLTransactionSurvivesCommitDelayBeyondWriteTimeout is the
+// ship-blocker regression test: a transaction carrying DDL that PREPAREs
+// successfully across the cluster must also be able to COMMIT within the DDL
+// validation timeout, even when a remote COMMIT RPC is slower than the
+// regular write timeout. Before the fix, sendRemoteCommits bound every remote
+// COMMIT RPC with a detached context.WithTimeout(context.Background(),
+// wc.timeout) - the regular (short) write timeout - so a DDL COMMIT taking
+// longer than that but well within the DDL validation timeout was abandoned,
+// producing a PartialCommitError while the coordinator's own local commit
+// still succeeded.
+func TestRunCommitPhase_DDLTransactionSurvivesCommitDelayBeyondWriteTimeout(t *testing.T) {
+	InitTestTelemetry()
+	withDDLValidationTimeout(t, 2000) // 2s DDL validation timeout
+
+	nodes := []uint64{1, 2, 3}
+	nodeProvider := newMockNodeProvider(nodes)
+	remoteReplicator := newMockReplicator()
+	localReplicator := newMockReplicator()
+
+	txn := NewTxnBuilder().WithID(910).WithNodeID(1).WithDatabase("test").
+		WithDDLStatement("CREATE TABLE t (id INT)").Build()
+
+	// Remote COMMIT for this txn takes 500ms: slower than the regular write
+	// timeout (100ms) used below, well under the DDL validation timeout (2s).
+	remoteReplicator.SetDelay(txn.ID, 500*time.Millisecond)
+
+	// wc.timeout stands in for the regular write timeout (write_timeout_ms).
+	wc := NewWriteCoordinator(1, nodeProvider, remoteReplicator, localReplicator, 100*time.Millisecond, nil)
+
+	prepResponses := map[uint64]*ReplicationResponse{
+		1: CreateSuccessResponse(),
+		2: CreateSuccessResponse(),
+		3: CreateSuccessResponse(),
+	}
+	cluster := &ClusterState{AliveNodes: nodes, TotalMembership: 3, RequiredQuorum: 2}
+
+	err := wc.runCommitPhase(context.Background(), txn, cluster, prepResponses)
+
+	AssertNoError(t, err)
+
+	localCalls := localReplicator.GetPhaseCalls(PhaseCommit)
+	if len(localCalls) != 1 {
+		t.Errorf("expected exactly 1 local commit call, got %d", len(localCalls))
+	}
+}
+
+// TestRunCommitPhase_DMLTransactionCommitStillTimesOutAtWriteTimeout is the
+// control for the test above: a DML transaction (no DDL) must NOT inherit the
+// DDL validation timeout for COMMIT. The same delay that a DDL transaction
+// survives must still produce a PartialCommitError for a DML transaction,
+// proving the regular write timeout still applies where it should.
+func TestRunCommitPhase_DMLTransactionCommitStillTimesOutAtWriteTimeout(t *testing.T) {
+	InitTestTelemetry()
+	withDDLValidationTimeout(t, 2000)
+
+	// writeTimeoutForStatements reads the regular write timeout from
+	// cfg.Config (getWriteTimeout), not from wc.timeout directly - in
+	// production the two are always the same value (marmot.go derives
+	// wc.timeout from this same config field), so pin them together here too.
+	originalWriteTimeoutMS := cfg.Config.Replication.WriteTimeoutMS
+	cfg.Config.Replication.WriteTimeoutMS = 100
+	t.Cleanup(func() { cfg.Config.Replication.WriteTimeoutMS = originalWriteTimeoutMS })
+
+	nodes := []uint64{1, 2, 3}
+	nodeProvider := newMockNodeProvider(nodes)
+	remoteReplicator := newMockReplicator()
+	localReplicator := newMockReplicator()
+
+	txn := NewTxnBuilder().WithID(911).WithNodeID(1).WithDatabase("test").
+		WithCDCStatement("users", map[string][]byte{"id": {1}}, map[string][]byte{"id": {2}}).Build()
+
+	remoteReplicator.SetDelay(txn.ID, 500*time.Millisecond)
+
+	wc := NewWriteCoordinator(1, nodeProvider, remoteReplicator, localReplicator, 100*time.Millisecond, nil)
+
+	prepResponses := map[uint64]*ReplicationResponse{
+		1: CreateSuccessResponse(),
+		2: CreateSuccessResponse(),
+		3: CreateSuccessResponse(),
+	}
+	cluster := &ClusterState{AliveNodes: nodes, TotalMembership: 3, RequiredQuorum: 2}
+
+	err := wc.runCommitPhase(context.Background(), txn, cluster, prepResponses)
+
+	AssertError(t, err, &PartialCommitError{})
+
+	localCalls := localReplicator.GetPhaseCalls(PhaseCommit)
+	if len(localCalls) > 0 {
+		t.Errorf("expected local commit NOT to be attempted for a DML timeout, got %d calls", len(localCalls))
+	}
+}

--- a/coordinator/write_coordinator_commithelpers_test.go
+++ b/coordinator/write_coordinator_commithelpers_test.go
@@ -33,7 +33,7 @@ func TestSendRemoteCommits_SpawnCorrectGoroutineCount(t *testing.T) {
 	beforeCalls := mock.GetCallCount()
 
 	// Execute
-	commitChan := wc.sendRemoteCommits(ctx, preparedNodes, req, 100)
+	commitChan := wc.sendRemoteCommits(ctx, preparedNodes, req, 100, wc.timeout)
 
 	// Wait for goroutines to execute
 	time.Sleep(50 * time.Millisecond)
@@ -70,7 +70,7 @@ func TestSendRemoteCommits_ExcludeCoordinator(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	wc.sendRemoteCommits(ctx, preparedNodes, req, 101)
+	wc.sendRemoteCommits(ctx, preparedNodes, req, 101, wc.timeout)
 
 	// Wait for goroutines
 	time.Sleep(50 * time.Millisecond)
@@ -137,7 +137,7 @@ func TestSendRemoteCommits_ChannelCapacityMatch(t *testing.T) {
 				Phase: PhaseCommit,
 			}
 
-			commitChan := wc.sendRemoteCommits(context.Background(), tc.preparedNodes, req, 200)
+			commitChan := wc.sendRemoteCommits(context.Background(), tc.preparedNodes, req, 200, wc.timeout)
 
 			if cap(commitChan) != tc.expectedCap {
 				t.Errorf("expected channel capacity %d, got %d", tc.expectedCap, cap(commitChan))
@@ -175,7 +175,7 @@ func TestSendRemoteCommits_DetachedContext(t *testing.T) {
 	beforeCalls := mock.GetCallCount()
 
 	// Execute
-	commitChan := wc.sendRemoteCommits(parentCtx, preparedNodes, req, 300)
+	commitChan := wc.sendRemoteCommits(parentCtx, preparedNodes, req, 300, wc.timeout)
 
 	// Cancel parent context IMMEDIATELY (before commits complete)
 	cancel()
@@ -226,7 +226,7 @@ func TestSendRemoteCommits_EmptyPreparedNodes(t *testing.T) {
 	beforeCalls := mock.GetCallCount()
 
 	// Execute
-	commitChan := wc.sendRemoteCommits(context.Background(), preparedNodes, req, 400)
+	commitChan := wc.sendRemoteCommits(context.Background(), preparedNodes, req, 400, wc.timeout)
 
 	// Wait a bit
 	time.Sleep(20 * time.Millisecond)
@@ -262,7 +262,7 @@ func TestSendRemoteCommits_SingleRemoteNode(t *testing.T) {
 	beforeCalls := mock.GetCallCount()
 
 	// Execute
-	commitChan := wc.sendRemoteCommits(context.Background(), preparedNodes, req, 500)
+	commitChan := wc.sendRemoteCommits(context.Background(), preparedNodes, req, 500, wc.timeout)
 
 	// Wait for goroutine
 	time.Sleep(50 * time.Millisecond)
@@ -308,7 +308,7 @@ func TestSendRemoteCommits_TimeoutPropagation(t *testing.T) {
 	}
 
 	// Execute - this spawns goroutines with detached context
-	wc.sendRemoteCommits(context.Background(), preparedNodes, req, 600)
+	wc.sendRemoteCommits(context.Background(), preparedNodes, req, 600, wc.timeout)
 
 	// Wait for goroutine to start
 	time.Sleep(20 * time.Millisecond)
@@ -344,7 +344,7 @@ func TestSendRemoteCommits_CorrectTxnID(t *testing.T) {
 	}
 
 	// Execute
-	wc.sendRemoteCommits(context.Background(), preparedNodes, req, expectedTxnID)
+	wc.sendRemoteCommits(context.Background(), preparedNodes, req, expectedTxnID, wc.timeout)
 
 	// Wait for goroutines
 	time.Sleep(50 * time.Millisecond)
@@ -381,7 +381,7 @@ func TestWaitForRemoteQuorum_ExactQuorumAchieved(t *testing.T) {
 	mocker.SendResponse(commitChan, 4, CreateErrorResponse("timeout"), 10*time.Millisecond)
 
 	// Execute: 3 prepared nodes, need 2 for quorum
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 100)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 100, wc.timeout)
 
 	// Assert: Exactly 2 ACKs
 	if acks != 2 {
@@ -413,7 +413,7 @@ func TestWaitForRemoteQuorum_OverQuorumAchieved(t *testing.T) {
 	mocker.SendResponse(commitChan, 5, CreateSuccessResponse(), 0)
 
 	// Execute: 4 prepared nodes, need 2 for quorum
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 4, 2, 200)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 4, 2, 200, wc.timeout)
 
 	// Assert: Early exit after 2 ACKs (may have 2, 3, or 4 depending on timing)
 	if acks < 2 {
@@ -443,7 +443,7 @@ func TestWaitForRemoteQuorum_UnderQuorumTimeout(t *testing.T) {
 	start := time.Now()
 
 	// Execute: 3 prepared nodes, need 2 for quorum (will timeout)
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 300)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 300, wc.timeout)
 
 	elapsed := time.Since(start)
 
@@ -482,7 +482,7 @@ func TestWaitForRemoteQuorum_EarlyExitOnQuorum(t *testing.T) {
 	start := time.Now()
 
 	// Execute: 4 prepared nodes, need 2 for quorum
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 4, 2, 400)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 4, 2, 400, wc.timeout)
 
 	elapsed := time.Since(start)
 
@@ -516,7 +516,7 @@ func TestWaitForRemoteQuorum_AllNodesFail(t *testing.T) {
 	mocker.SendResponse(commitChan, 4, CreateErrorResponse("unreachable"), 0)
 
 	// Execute: 3 prepared nodes, need 2 for quorum
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 500)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 500, wc.timeout)
 
 	// Assert: 0 ACKs
 	if acks != 0 {
@@ -544,7 +544,7 @@ func TestWaitForRemoteQuorum_MixedSuccessError(t *testing.T) {
 	mocker.SendResponse(commitChan, 5, CreateSuccessResponse(), 0)
 
 	// Execute: 4 prepared nodes, need 2 for quorum
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 4, 2, 600)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 4, 2, 600, wc.timeout)
 
 	// Assert: 2 or 3 ACKs (early exit after 2, but may collect more)
 	if acks < 2 {
@@ -580,7 +580,7 @@ func TestWaitForRemoteQuorum_TimeoutPerResponse(t *testing.T) {
 	mocker.SendResponse(commitChan, 4, CreateSuccessResponse(), 0)
 
 	// Execute: 3 prepared nodes, need 2 for quorum
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 700)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 700, wc.timeout)
 
 	// Assert: Got 2 ACKs (nodes 2 and 4, node 3 timed out)
 	if acks != 2 {
@@ -607,7 +607,7 @@ func TestWaitForRemoteQuorum_ZeroQuorumNeeded(t *testing.T) {
 	// Execute: remoteQuorumNeeded = 0 (single-node or coordinator-only)
 	// Even though quorum is 0, the loop still runs once per otherPreparedNodes
 	// But should exit early after checking the condition
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 2, 0, 800)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 2, 0, 800, wc.timeout)
 
 	// Assert: 0 ACKs (quorum already met)
 	if acks != 0 {
@@ -632,7 +632,7 @@ func TestWaitForRemoteQuorum_NegativeQuorumNeeded(t *testing.T) {
 
 	// Execute: remoteQuorumNeeded = -1 (invalid, but should handle gracefully)
 	// The condition remoteAcks >= -1 is always true, so should exit after first iteration
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 2, -1, 900)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 2, -1, 900, wc.timeout)
 
 	// Assert: 0 ACKs (no successful responses collected before exit)
 	if acks != 0 {
@@ -667,7 +667,7 @@ func TestWaitForRemoteQuorum_ChannelClosed(t *testing.T) {
 	}()
 
 	// Execute: 2 prepared nodes, need 2 for quorum (but channel closes after 1)
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 2, 2, 1000)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 2, 2, 1000, wc.timeout)
 
 	// Assert: Got only 1 ACK (channel closed early)
 	if acks != 1 {
@@ -705,7 +705,7 @@ func TestWaitForRemoteQuorum_NilResponses(t *testing.T) {
 	}
 
 	// Execute: 3 prepared nodes, need 2 for quorum
-	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 1100)
+	responses, acks := wc.waitForRemoteQuorum(commitChan, 3, 2, 1100, wc.timeout)
 
 	// Assert: Only 1 ACK (nil and error not counted)
 	if acks != 1 {

--- a/coordinator/write_coordinator_executeprepare_test.go
+++ b/coordinator/write_coordinator_executeprepare_test.go
@@ -5,7 +5,20 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/maxpert/marmot/cfg"
 )
+
+// withDDLValidationTimeout temporarily overrides the configured DDL validation
+// timeout for the duration of a test, restoring the prior value afterward.
+// cfg.Config is a process-global, so tests using this must not run in
+// parallel with each other or with anything else reading the same field.
+func withDDLValidationTimeout(t *testing.T, ms int) {
+	t.Helper()
+	original := cfg.Config.Replication.DDLValidationTimeoutMS
+	cfg.Config.Replication.DDLValidationTimeoutMS = ms
+	t.Cleanup(func() { cfg.Config.Replication.DDLValidationTimeoutMS = original })
+}
 
 // TestExecutePreparePhase_BroadcastToAllNodes verifies that prepare requests are broadcast to all nodes
 // Test 5.1: All nodes should receive prepare requests and responses should be collected
@@ -34,7 +47,7 @@ func TestExecutePreparePhase_BroadcastToAllNodes(t *testing.T) {
 	ctx, cancel := WithTimeout(200)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	AssertNoError(t, err)
 	AssertResponseMapSize(t, responses, 5) // coordinator + 4 others
@@ -77,7 +90,7 @@ func TestExecutePreparePhase_SkipLocalReplication_False(t *testing.T) {
 	ctx, cancel := WithTimeout(200)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	AssertNoError(t, err)
 	AssertResponseMapSize(t, responses, 3) // coordinator + 2 others
@@ -124,7 +137,7 @@ func TestExecutePreparePhase_SkipLocalReplication_True(t *testing.T) {
 	ctx, cancel := WithTimeout(200)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, true)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, true)
 
 	AssertNoError(t, err)
 	AssertResponseMapSize(t, responses, 3) // only other nodes
@@ -174,7 +187,7 @@ func TestExecutePreparePhase_ConcurrentExecution(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 	elapsed := time.Since(start)
 
 	AssertNoError(t, err)
@@ -220,7 +233,7 @@ func TestExecutePreparePhase_ResponseTimeout(t *testing.T) {
 	ctx, cancel := WithTimeout(300)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	AssertNoError(t, err)
 
@@ -271,7 +284,7 @@ func TestExecutePreparePhase_MixedResponses(t *testing.T) {
 	ctx, cancel := WithTimeout(200)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	// Conflict should be returned as error
 	if err == nil {
@@ -319,7 +332,7 @@ func TestExecutePreparePhase_AllNodesTimeout(t *testing.T) {
 	ctx, cancel := WithTimeout(300)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	AssertNoError(t, err)
 
@@ -360,7 +373,7 @@ func TestExecutePreparePhase_ContextCancelled(t *testing.T) {
 	CancelAfter(ctx, cancel, 20*time.Millisecond)
 
 	start := time.Now()
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 	elapsed := time.Since(start)
 
 	// Should return quickly after context cancellation
@@ -406,7 +419,7 @@ func TestExecutePreparePhase_NilResponse(t *testing.T) {
 	ctx, cancel := WithTimeout(200)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	AssertNoError(t, err)
 
@@ -448,7 +461,7 @@ func TestExecutePreparePhase_ZeroTotalNodes(t *testing.T) {
 	ctx, cancel := WithTimeout(200)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, true)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, true)
 
 	AssertNoError(t, err)
 	AssertResponseMapSize(t, responses, 0)
@@ -493,7 +506,7 @@ func TestExecutePreparePhase_ChannelBufferOverflow(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 	elapsed := time.Since(start)
 
 	AssertNoError(t, err)
@@ -539,7 +552,7 @@ func TestExecutePreparePhase_GoroutineLeakPrevention(t *testing.T) {
 
 	beforeGoroutines := CountGoroutines()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	AssertNoError(t, err)
 
@@ -588,7 +601,7 @@ func TestExecutePreparePhase_ConflictStopsCollection(t *testing.T) {
 	ctx, cancel := WithTimeout(200)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	// Should return conflict error
 	if err == nil {
@@ -636,7 +649,7 @@ func TestExecutePreparePhase_ErrorResponsesNotAdded(t *testing.T) {
 	ctx, cancel := WithTimeout(200)
 	defer cancel()
 
-	responses, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
 
 	AssertNoError(t, err)
 
@@ -692,7 +705,7 @@ func TestExecutePreparePhase_CallsAreDeadlineBounded(t *testing.T) {
 
 	// Parent context has no deadline of its own - the bound must come from wc.timeout
 	start := time.Now()
-	responses, err := wc.executePreparePhase(context.Background(), txn, req, []uint64{2, 3}, false)
+	responses, _, err := wc.executePreparePhase(context.Background(), txn, req, []uint64{2, 3}, false)
 
 	AssertNoError(t, err)
 	AssertResponseMapSize(t, responses, 3)
@@ -711,4 +724,161 @@ func TestExecutePreparePhase_CallsAreDeadlineBounded(t *testing.T) {
 			t.Errorf("call %d deadline exceeds coordinator timeout: %v > %v", i, budget, wc.timeout)
 		}
 	}
+}
+
+// TestExecutePreparePhase_DDLCallsUseDDLValidationTimeout verifies that a
+// transaction carrying a DDL statement is dispatched with the DDL validation
+// timeout, not the regular (much shorter) write timeout. PREPARE for DDL
+// executes the real statement in a rolled-back transaction, which the regular
+// write timeout is not sized for.
+func TestExecutePreparePhase_DDLCallsUseDDLValidationTimeout(t *testing.T) {
+	defer CheckGoroutines(t)()
+	withDDLValidationTimeout(t, 2000)
+
+	recorder := &deadlineRecordingReplicator{}
+	wc := &WriteCoordinator{
+		nodeID:          1,
+		replicator:      recorder,
+		localReplicator: recorder,
+		timeout:         100 * time.Millisecond, // regular write timeout - deliberately short
+	}
+
+	txn := NewTxnBuilder().WithID(300).WithDDLStatement("CREATE TABLE t (id INT)").Build()
+	req := &ReplicationRequest{TxnID: txn.ID, NodeID: wc.nodeID, Phase: PhasePrep, Database: txn.Database}
+
+	start := time.Now()
+	responses, _, err := wc.executePreparePhase(context.Background(), txn, req, []uint64{2, 3}, false)
+
+	AssertNoError(t, err)
+	AssertResponseMapSize(t, responses, 3)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	if len(recorder.deadlines) != 3 {
+		t.Fatalf("recorded deadlines: got %d, want 3", len(recorder.deadlines))
+	}
+	for i, deadline := range recorder.deadlines {
+		budget := deadline.Sub(start)
+		// A wide margin above wc.timeout (100ms) is required, not just "greater
+		// than" it: scheduling jitter alone can push the recorded budget a few
+		// hundred microseconds past wc.timeout even when the DDL timeout was NOT
+		// applied, which would make a tight "> wc.timeout" check pass vacuously.
+		if budget < 1*time.Second {
+			t.Errorf("call %d deadline budget %v is not comfortably above the regular write timeout %v - DDL validation timeout was not applied", i, budget, wc.timeout)
+		}
+		if budget > 2000*time.Millisecond+100*time.Millisecond {
+			t.Errorf("call %d deadline budget %v exceeds the configured DDL validation timeout (2000ms)", i, budget)
+		}
+	}
+}
+
+// TestExecutePreparePhase_DMLCallsKeepRegularWriteTimeout is the control for
+// TestExecutePreparePhase_DDLCallsUseDDLValidationTimeout: a transaction with
+// no DDL statement must keep using the regular write timeout even when a much
+// larger DDL validation timeout is configured, so ordinary writes are not
+// silently slowed down by a knob meant only for DDL.
+func TestExecutePreparePhase_DMLCallsKeepRegularWriteTimeout(t *testing.T) {
+	defer CheckGoroutines(t)()
+	withDDLValidationTimeout(t, 2000)
+
+	recorder := &deadlineRecordingReplicator{}
+	wc := &WriteCoordinator{
+		nodeID:          1,
+		replicator:      recorder,
+		localReplicator: recorder,
+		timeout:         100 * time.Millisecond,
+	}
+
+	txn := NewTxnBuilder().WithID(301).
+		WithCDCStatement("users", map[string][]byte{"id": {1}}, map[string][]byte{"id": {2}}).
+		Build()
+	req := &ReplicationRequest{TxnID: txn.ID, NodeID: wc.nodeID, Phase: PhasePrep, Database: txn.Database}
+
+	start := time.Now()
+	responses, _, err := wc.executePreparePhase(context.Background(), txn, req, []uint64{2, 3}, false)
+
+	AssertNoError(t, err)
+	AssertResponseMapSize(t, responses, 3)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	if len(recorder.deadlines) != 3 {
+		t.Fatalf("recorded deadlines: got %d, want 3", len(recorder.deadlines))
+	}
+	for i, deadline := range recorder.deadlines {
+		if budget := deadline.Sub(start); budget > wc.timeout+50*time.Millisecond {
+			t.Errorf("call %d deadline budget %v exceeds the regular write timeout %v - DML must not inherit the DDL validation timeout", i, budget, wc.timeout)
+		}
+	}
+}
+
+// TestExecutePreparePhase_DDLTransactionSurvivesDelayBeyondWriteTimeout proves
+// the DDL validation timeout is not just recorded on the context but actually
+// changes outcomes: a remote PREPARE call slower than the regular write
+// timeout but faster than the DDL validation timeout must still succeed for a
+// DDL transaction.
+func TestExecutePreparePhase_DDLTransactionSurvivesDelayBeyondWriteTimeout(t *testing.T) {
+	defer CheckGoroutines(t)()
+	withDDLValidationTimeout(t, 2000)
+
+	mock := newMockReplicator()
+	localMock := newMockReplicator()
+	wc := &WriteCoordinator{
+		nodeID:          1,
+		replicator:      mock,
+		localReplicator: localMock,
+		timeout:         100 * time.Millisecond, // regular write timeout
+	}
+
+	txn := NewTxnBuilder().WithID(302).WithDDLStatement("CREATE TABLE t (id INT)").Build()
+	req := &ReplicationRequest{TxnID: txn.ID, NodeID: wc.nodeID, Phase: PhasePrep, Database: txn.Database}
+
+	// Slower than the regular write timeout (100ms), well under the DDL
+	// validation timeout (2s).
+	mock.SetDelay(txn.ID, 500*time.Millisecond)
+	otherNodes := []uint64{2}
+
+	ctx, cancel := WithTimeout(3000)
+	defer cancel()
+
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+
+	AssertNoError(t, err)
+	AssertResponseSuccess(t, responses, 2)
+}
+
+// TestExecutePreparePhase_DMLTransactionTimesOutAtWriteTimeout is the control
+// for the delay test above: the same delay applied to a DML transaction must
+// still time out at the regular write timeout, proving DML did not silently
+// inherit the DDL validation timeout.
+func TestExecutePreparePhase_DMLTransactionTimesOutAtWriteTimeout(t *testing.T) {
+	defer CheckGoroutines(t)()
+	withDDLValidationTimeout(t, 2000)
+
+	mock := newMockReplicator()
+	localMock := newMockReplicator()
+	wc := &WriteCoordinator{
+		nodeID:          1,
+		replicator:      mock,
+		localReplicator: localMock,
+		timeout:         100 * time.Millisecond,
+	}
+
+	txn := NewTxnBuilder().WithID(303).
+		WithCDCStatement("users", map[string][]byte{"id": {1}}, map[string][]byte{"id": {2}}).
+		Build()
+	req := &ReplicationRequest{TxnID: txn.ID, NodeID: wc.nodeID, Phase: PhasePrep, Database: txn.Database}
+
+	mock.SetDelay(txn.ID, 500*time.Millisecond)
+	otherNodes := []uint64{2}
+
+	ctx, cancel := WithTimeout(3000)
+	defer cancel()
+
+	responses, _, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+
+	AssertNoError(t, err)
+	AssertNodeNotInResponses(t, responses, 2)
 }

--- a/coordinator/write_coordinator_executeprepare_test.go
+++ b/coordinator/write_coordinator_executeprepare_test.go
@@ -1,6 +1,8 @@
 package coordinator
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -647,4 +649,66 @@ func TestExecutePreparePhase_ErrorResponsesNotAdded(t *testing.T) {
 	// Verify coordinator and node 3 are successful
 	AssertResponseSuccess(t, responses, wc.nodeID)
 	AssertResponseSuccess(t, responses, 3)
+}
+
+// deadlineRecordingReplicator captures the context deadline of each PREPARE call.
+type deadlineRecordingReplicator struct {
+	mu        sync.Mutex
+	deadlines []time.Time
+	hadNone   bool
+}
+
+func (d *deadlineRecordingReplicator) ReplicateTransaction(ctx context.Context, nodeID uint64, _ *ReplicationRequest) (*ReplicationResponse, error) {
+	deadline, ok := ctx.Deadline()
+
+	d.mu.Lock()
+	if ok {
+		d.deadlines = append(d.deadlines, deadline)
+	} else {
+		d.hadNone = true
+	}
+	d.mu.Unlock()
+
+	return &ReplicationResponse{Success: true}, nil
+}
+
+// TestExecutePreparePhase_CallsAreDeadlineBounded verifies every PREPARE call is
+// bounded by the coordinator timeout. PREPARE persists intents and validates DDL,
+// so a call the collector has given up on must not keep running and durably
+// prepare a transaction the coordinator no longer tracks.
+func TestExecutePreparePhase_CallsAreDeadlineBounded(t *testing.T) {
+	defer CheckGoroutines(t)()
+
+	recorder := &deadlineRecordingReplicator{}
+	wc := &WriteCoordinator{
+		nodeID:          1,
+		replicator:      recorder,
+		localReplicator: recorder,
+		timeout:         200 * time.Millisecond,
+	}
+
+	txn := NewTxnBuilder().WithID(100).Build()
+	req := &ReplicationRequest{TxnID: txn.ID, NodeID: wc.nodeID, Phase: PhasePrep, Database: txn.Database}
+
+	// Parent context has no deadline of its own - the bound must come from wc.timeout
+	start := time.Now()
+	responses, err := wc.executePreparePhase(context.Background(), txn, req, []uint64{2, 3}, false)
+
+	AssertNoError(t, err)
+	AssertResponseMapSize(t, responses, 3)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	if recorder.hadNone {
+		t.Error("PREPARE dispatched with an unbounded context")
+	}
+	if len(recorder.deadlines) != 3 {
+		t.Fatalf("recorded deadlines: got %d, want 3", len(recorder.deadlines))
+	}
+	for i, deadline := range recorder.deadlines {
+		if budget := deadline.Sub(start); budget > wc.timeout+50*time.Millisecond {
+			t.Errorf("call %d deadline exceeds coordinator timeout: %v > %v", i, budget, wc.timeout)
+		}
+	}
 }

--- a/coordinator/write_coordinator_remote_rejection_test.go
+++ b/coordinator/write_coordinator_remote_rejection_test.go
@@ -1,0 +1,191 @@
+package coordinator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/maxpert/marmot/hlc"
+	"github.com/maxpert/marmot/protocol"
+)
+
+// ========================================
+// Remote PREPARE rejection over the wire
+//
+// A remote participant's deterministic PREPARE rejection (e.g. DDL SQLite
+// cannot apply) must not be treated as a mere missing ACK once quorum has
+// already failed to form: retrying cannot change that participant's verdict.
+// But the same rejection must carry no veto power while quorum is otherwise
+// achieved - a single node cannot block cluster DDL.
+// ========================================
+
+// TestExecutePreparePhase_RemoteRejectionTracked verifies executePreparePhase
+// surfaces a remote (non-local) explicit rejection via its third return value,
+// while leaving the map/err results used for quorum counting unaffected - a
+// remote rejection is not itself a final answer.
+func TestExecutePreparePhase_RemoteRejectionTracked(t *testing.T) {
+	InitTestTelemetry()
+
+	mock := newMockReplicator()
+	wc := &WriteCoordinator{
+		nodeID:          1,
+		replicator:      mock,
+		localReplicator: mock,
+		timeout:         100 * time.Millisecond,
+	}
+
+	txn := NewTxnBuilder().WithID(200).Build()
+	req := &ReplicationRequest{
+		TxnID:    txn.ID,
+		NodeID:   wc.nodeID,
+		Phase:    PhasePrep,
+		Database: txn.Database,
+	}
+
+	mock.SetNodeResponse(2, CreateRejectionResponse("duplicate column name: creation_date"))
+	otherNodes := []uint64{2, 3}
+
+	ctx, cancel := WithTimeout(200)
+	defer cancel()
+
+	responses, remoteRejection, err := wc.executePreparePhase(ctx, txn, req, otherNodes, false)
+
+	AssertNoError(t, err)
+	if remoteRejection == nil {
+		t.Fatal("expected a tracked remote rejection, got nil")
+	}
+	if remoteRejection.NodeID != 2 {
+		t.Errorf("rejecting node: got %d, want 2", remoteRejection.NodeID)
+	}
+	if remoteRejection.Reason != "duplicate column name: creation_date" {
+		t.Errorf("reason: got %q, want %q", remoteRejection.Reason, "duplicate column name: creation_date")
+	}
+
+	// The rejecting node must not appear as prepared, but the rejection is not
+	// a final verdict at this layer - the map still holds the nodes that did
+	// prepare successfully.
+	AssertNodeNotInResponses(t, responses, 2)
+	AssertResponseSuccess(t, responses, wc.nodeID)
+	AssertResponseSuccess(t, responses, 3)
+}
+
+// TestRunPreparePhase_QuorumFailureWithRemoteRejectionIsFinal is the policy
+// test: when quorum fails to form AND a remote participant explicitly
+// rejected, the coordinator must return a final, non-retryable error carrying
+// that participant's own reason - not the retryable QuorumNotAchievedError.
+func TestRunPreparePhase_QuorumFailureWithRemoteRejectionIsFinal(t *testing.T) {
+	InitTestTelemetry()
+
+	nodeProvider := newMockNodeProvider([]uint64{1, 2, 3, 4, 5})
+	localReplicator := newMockReplicator()
+	remoteReplicator := newMockReplicator()
+
+	// Quorum for 5 nodes is 3. Node 2 succeeds (2 total acks with coordinator).
+	// Node 3 explicitly rejects (deterministic DDL verdict). Nodes 4,5 time out.
+	remoteReplicator.SetNodeResponse(3, CreateRejectionResponse("duplicate column name: creation_date"))
+	remoteReplicator.SetNodeResponse(4, nil)
+	remoteReplicator.SetNodeResponse(5, nil)
+
+	wc := NewWriteCoordinator(1, nodeProvider, remoteReplicator, localReplicator, 50*time.Millisecond, hlc.NewClock(1))
+
+	txn := NewTxnBuilder().WithID(201).Build()
+	cluster, _ := GetClusterState(nodeProvider, txn.WriteConsistency)
+	otherNodes := []uint64{2, 3, 4, 5}
+
+	ctx := context.Background()
+	_, err := wc.runPreparePhase(ctx, txn, cluster, otherNodes)
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+
+	var quorumErr *QuorumNotAchievedError
+	if errors.As(err, &quorumErr) {
+		t.Fatalf("expected a non-retryable RemotePrepareRejectedError, got the retryable QuorumNotAchievedError: %v", err)
+	}
+
+	var rejectedErr *RemotePrepareRejectedError
+	if !errors.As(err, &rejectedErr) {
+		t.Fatalf("expected *RemotePrepareRejectedError, got %T: %v", err, err)
+	}
+	if rejectedErr.NodeID != 3 {
+		t.Errorf("rejecting node: got %d, want 3", rejectedErr.NodeID)
+	}
+	if rejectedErr.Reason != "duplicate column name: creation_date" {
+		t.Errorf("reason: got %q, want %q", rejectedErr.Reason, "duplicate column name: creation_date")
+	}
+
+	// The client must receive the real statement error (1060/42S21), not a
+	// retry signal (1213), or it retries forever against a verdict that can
+	// never change.
+	mysqlErr := protocol.ConvertToMySQLError(err)
+	if mysqlErr.Code != protocol.ErrCodeDupFieldName {
+		t.Errorf("MySQL error code: got %d, want %d (ErrCodeDupFieldName)", mysqlErr.Code, protocol.ErrCodeDupFieldName)
+	}
+	if mysqlErr.SQLState != protocol.SQLStateDupColumn {
+		t.Errorf("MySQL SQLSTATE: got %q, want %q", mysqlErr.SQLState, protocol.SQLStateDupColumn)
+	}
+}
+
+// TestRunPreparePhase_QuorumFailureWithoutRejectionStaysRetryable is the
+// regression guard: quorum failing on plain timeouts/errors, with no
+// participant issuing an explicit rejection, must keep returning the
+// retryable QuorumNotAchievedError exactly as before this change.
+func TestRunPreparePhase_QuorumFailureWithoutRejectionStaysRetryable(t *testing.T) {
+	InitTestTelemetry()
+
+	nodeProvider := newMockNodeProvider([]uint64{1, 2, 3, 4, 5})
+	localReplicator := newMockReplicator()
+	remoteReplicator := newMockReplicator()
+
+	remoteReplicator.SetNodeResponse(3, nil)
+	remoteReplicator.SetNodeResponse(4, nil)
+	remoteReplicator.SetNodeResponse(5, nil)
+
+	wc := NewWriteCoordinator(1, nodeProvider, remoteReplicator, localReplicator, 50*time.Millisecond, hlc.NewClock(1))
+
+	txn := NewTxnBuilder().WithID(202).Build()
+	cluster, _ := GetClusterState(nodeProvider, txn.WriteConsistency)
+	otherNodes := []uint64{2, 3, 4, 5}
+
+	ctx := context.Background()
+	_, err := wc.runPreparePhase(ctx, txn, cluster, otherNodes)
+
+	AssertQuorumNotAchievedError(t, err, "prepare", 2, 3)
+
+	var rejectedErr *RemotePrepareRejectedError
+	if errors.As(err, &rejectedErr) {
+		t.Fatalf("did not expect a RemotePrepareRejectedError when nothing rejected: %v", err)
+	}
+}
+
+// TestRunPreparePhase_RemoteRejectionDoesNotVetoAchievedQuorum is the "no veto
+// power" half of the policy: a remote rejection must never abort a
+// transaction that otherwise reaches quorum.
+func TestRunPreparePhase_RemoteRejectionDoesNotVetoAchievedQuorum(t *testing.T) {
+	InitTestTelemetry()
+
+	nodeProvider := newMockNodeProvider([]uint64{1, 2, 3, 4, 5})
+	localReplicator := newMockReplicator()
+	remoteReplicator := newMockReplicator()
+
+	// Quorum for 5 nodes is 3. Node 2 explicitly rejects, but nodes 3 and 4
+	// succeed alongside the coordinator, so quorum (3) is still reached.
+	remoteReplicator.SetNodeResponse(2, CreateRejectionResponse("duplicate column name: creation_date"))
+
+	wc := NewWriteCoordinator(1, nodeProvider, remoteReplicator, localReplicator, 100*time.Millisecond, hlc.NewClock(1))
+
+	txn := NewTxnBuilder().WithID(203).Build()
+	cluster, _ := GetClusterState(nodeProvider, txn.WriteConsistency)
+	otherNodes := []uint64{2, 3, 4}
+
+	ctx := context.Background()
+	responses, err := wc.runPreparePhase(ctx, txn, cluster, otherNodes)
+
+	AssertNoError(t, err)
+	AssertNodeNotInResponses(t, responses, 2)
+	AssertResponseSuccess(t, responses, wc.nodeID)
+	AssertResponseSuccess(t, responses, 3)
+	AssertResponseSuccess(t, responses, 4)
+}

--- a/coordinator/write_coordinator_runprepare_test.go
+++ b/coordinator/write_coordinator_runprepare_test.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -64,6 +65,79 @@ func TestRunPreparePhase_CoordinatorPrepareFails(t *testing.T) {
 	ctx := context.Background()
 	_, err := wc.runPreparePhase(ctx, txn, cluster, otherNodes)
 
+	AssertError(t, err, &CoordinatorNotParticipatedError{})
+}
+
+// Test 4.2b: CoordinatorPrepareRejectionReason
+// A deterministic local rejection (invalid DDL) must reach the client with the
+// participant's reason so it maps to the matching MySQL error code instead of a
+// generic "coordinator must participate" message.
+func TestRunPreparePhase_CoordinatorRejectionCarriesReason(t *testing.T) {
+	InitTestTelemetry()
+
+	nodeProvider := newMockNodeProvider([]uint64{1, 2, 3})
+	localReplicator := newMockReplicator()
+	remoteReplicator := newMockReplicator()
+
+	localReplicator.SetNodeResponse(1, CreateRejectionResponse("duplicate column name: creation_date"))
+
+	wc := NewWriteCoordinator(1, nodeProvider, remoteReplicator, localReplicator, 100*time.Millisecond, hlc.NewClock(1))
+
+	txn := NewTxnBuilder().WithID(1010).Build()
+	cluster, _ := GetClusterState(nodeProvider, txn.WriteConsistency)
+	otherNodes := []uint64{2, 3}
+
+	ctx := context.Background()
+	_, err := wc.runPreparePhase(ctx, txn, cluster, otherNodes)
+
+	AssertError(t, err, &CoordinatorNotParticipatedError{})
+
+	var localErr *LocalPrepareError
+	if !errors.As(err, &localErr) {
+		t.Fatalf("expected wrapped LocalPrepareError, got %v", err)
+	}
+	if localErr.Reason != "duplicate column name: creation_date" {
+		t.Errorf("reason: got %q, want %q", localErr.Reason, "duplicate column name: creation_date")
+	}
+
+	mysqlErr := protocol.ConvertToMySQLError(err)
+	if mysqlErr.Code != protocol.ErrCodeDupFieldName {
+		t.Errorf("MySQL error code: got %d, want %d", mysqlErr.Code, protocol.ErrCodeDupFieldName)
+	}
+}
+
+// Test 4.2c: A transient local failure (timeout, storage error) must NOT be
+// reported as a final rejection - it stays a missing ACK so the client keeps the
+// retryable behaviour it had before DDL was validated during PREPARE.
+func TestRunPreparePhase_TransientLocalFailureIsNotRejection(t *testing.T) {
+	InitTestTelemetry()
+
+	nodeProvider := newMockNodeProvider([]uint64{1, 2, 3})
+	localReplicator := newMockReplicator()
+	remoteReplicator := newMockReplicator()
+
+	// Success:false without Rejected - e.g. validation hit the context deadline
+	localReplicator.SetNodeResponse(1, CreateErrorResponse("failed to begin DDL validation transaction: context deadline exceeded"))
+
+	wc := NewWriteCoordinator(1, nodeProvider, remoteReplicator, localReplicator, 100*time.Millisecond, hlc.NewClock(1))
+
+	txn := NewTxnBuilder().WithID(1011).Build()
+	cluster, _ := GetClusterState(nodeProvider, txn.WriteConsistency)
+	otherNodes := []uint64{2, 3}
+
+	ctx := context.Background()
+	_, err := wc.runPreparePhase(ctx, txn, cluster, otherNodes)
+
+	if err == nil {
+		t.Fatal("expected prepare to fail when the coordinator does not participate")
+	}
+
+	var localErr *LocalPrepareError
+	if errors.As(err, &localErr) {
+		t.Errorf("transient local failure must not be classified as a rejection, got %v", err)
+	}
+
+	// It must still abort through the pre-existing coordinator-participation path.
 	AssertError(t, err, &CoordinatorNotParticipatedError{})
 }
 

--- a/coordinator/write_coordinator_unit_test_helpers.go
+++ b/coordinator/write_coordinator_unit_test_helpers.go
@@ -64,7 +64,8 @@ func (b *TxnBuilder) WithCDCStatement(tableName string, oldVals, newVals map[str
 // WithDDLStatement adds a DDL statement
 func (b *TxnBuilder) WithDDLStatement(sql string) *TxnBuilder {
 	stmt := protocol.Statement{
-		SQL: sql,
+		Type: protocol.StatementDDL,
+		SQL:  sql,
 	}
 	b.txn.Statements = append(b.txn.Statements, stmt)
 	return b

--- a/coordinator/write_coordinator_unit_test_helpers.go
+++ b/coordinator/write_coordinator_unit_test_helpers.go
@@ -619,6 +619,16 @@ func CreateErrorResponse(errMsg string) *ReplicationResponse {
 	}
 }
 
+// CreateRejectionResponse builds a response for a participant that deterministically
+// refused the statement (for example DDL SQLite cannot apply).
+func CreateRejectionResponse(errMsg string) *ReplicationResponse {
+	return &ReplicationResponse{
+		Success:  false,
+		Error:    errMsg,
+		Rejected: true,
+	}
+}
+
 // InitTestTelemetry initializes telemetry for tests
 // Note: In the current implementation, telemetry metrics default to noop implementations
 // This function is provided for future use when telemetry initialization is needed

--- a/coordinator/write_timeout_test.go
+++ b/coordinator/write_timeout_test.go
@@ -1,0 +1,92 @@
+package coordinator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maxpert/marmot/cfg"
+	"github.com/maxpert/marmot/protocol"
+)
+
+// TestGetDDLValidationTimeout_UsesConfiguredValue verifies the configured
+// value is honored.
+func TestGetDDLValidationTimeout_UsesConfiguredValue(t *testing.T) {
+	withDDLValidationTimeout(t, 12345)
+
+	got := getDDLValidationTimeout()
+	want := 12345 * time.Millisecond
+	if got != want {
+		t.Errorf("getDDLValidationTimeout(): got %v, want %v", got, want)
+	}
+}
+
+// TestGetDDLValidationTimeout_DefaultsWhenUnset verifies the 60s default is
+// used when the config value is not set (<= 0), mirroring getWriteTimeout's
+// defensive fallback for a nil or zero-value config.
+func TestGetDDLValidationTimeout_DefaultsWhenUnset(t *testing.T) {
+	withDDLValidationTimeout(t, 0)
+
+	got := getDDLValidationTimeout()
+	want := 60 * time.Second
+	if got != want {
+		t.Errorf("getDDLValidationTimeout(): got %v, want %v (default)", got, want)
+	}
+}
+
+// TestWriteTimeoutForStatements verifies the timeout selection: any DDL
+// statement in the transaction routes to the DDL validation timeout,
+// otherwise the regular write timeout is used - including for an empty
+// statement list and a transaction mixing DML and DDL.
+func TestWriteTimeoutForStatements(t *testing.T) {
+	withDDLValidationTimeout(t, 9000)
+	originalWrite := cfg.Config.Replication.WriteTimeoutMS
+	cfg.Config.Replication.WriteTimeoutMS = 500
+	t.Cleanup(func() { cfg.Config.Replication.WriteTimeoutMS = originalWrite })
+
+	ddlWant := 9000 * time.Millisecond
+	writeWant := 500 * time.Millisecond
+
+	cases := []struct {
+		name  string
+		stmts []protocol.Statement
+		want  time.Duration
+	}{
+		{
+			name:  "no statements",
+			stmts: nil,
+			want:  writeWant,
+		},
+		{
+			name:  "single DML statement",
+			stmts: []protocol.Statement{{Type: protocol.StatementInsert}},
+			want:  writeWant,
+		},
+		{
+			name:  "single DDL statement",
+			stmts: []protocol.Statement{{Type: protocol.StatementDDL}},
+			want:  ddlWant,
+		},
+		{
+			name: "mixed DML and DDL",
+			stmts: []protocol.Statement{
+				{Type: protocol.StatementInsert},
+				{Type: protocol.StatementDDL},
+			},
+			want: ddlWant,
+		},
+		{
+			name:  "vector index control is not DDL",
+			stmts: []protocol.Statement{{Type: protocol.StatementCreateVectorIndex}},
+			want:  writeWant,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := writeTimeoutForStatements(tc.stmts)
+			if got != tc.want {
+				t.Errorf("writeTimeoutForStatements(%s): got %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/db/database_manager.go
+++ b/db/database_manager.go
@@ -939,17 +939,27 @@ func (dm *DatabaseManager) checkpointDatabase(db *ReplicatedDatabase) error {
 // 1. Acquires write lock to block all writes
 // 2. Checkpoints all databases (TRUNCATE mode)
 // 3. Copies all database files to the target directory
-// 4. Releases write lock
+// 4. Reads schema versions for the copied databases
+// 5. Releases write lock
 //
 // The caller should stream from the target directory and clean it up when done.
 // This ensures snapshot consistency since files are copied atomically under lock.
-func (dm *DatabaseManager) TakeSnapshotToDir(targetDir string) ([]SnapshotInfo, uint64, error) {
+//
+// Schema versions are read from the system MetaStore in the same locked section
+// that produces the copied files, so the returned versions describe exactly the
+// bytes being handed back - not a value read by some earlier, separate call that
+// a concurrent DDL commit could have moved past. A caller that instead reads
+// schema versions via a different, earlier RPC (e.g. GetSnapshotInfo) can
+// observe a version that no longer matches the file bytes actually streamed
+// later; see SnapshotVersionsForRestore in the grpc package for how that is
+// resolved on the receiving side.
+func (dm *DatabaseManager) TakeSnapshotToDir(targetDir string) ([]SnapshotInfo, uint64, map[string]uint64, error) {
 	// Create target directory structure
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		return nil, 0, fmt.Errorf("failed to create snapshot directory: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to create snapshot directory: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Join(targetDir, "databases"), 0755); err != nil {
-		return nil, 0, fmt.Errorf("failed to create databases directory: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to create databases directory: %w", err)
 	}
 
 	// Acquire write lock to block all concurrent writes
@@ -963,21 +973,21 @@ func (dm *DatabaseManager) TakeSnapshotToDir(targetDir string) ([]SnapshotInfo, 
 	systemTargetPath := filepath.Join(targetDir, SystemDatabaseName+".db")
 
 	if err := dm.checkpointDatabase(dm.systemDB); err != nil {
-		return nil, 0, fmt.Errorf("failed to checkpoint system database: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to checkpoint system database: %w", err)
 	}
 
 	if err := copyFile(systemDBPath, systemTargetPath); err != nil {
-		return nil, 0, fmt.Errorf("failed to copy system database: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to copy system database: %w", err)
 	}
 
 	info, err := os.Stat(systemTargetPath)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to stat system database copy: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to stat system database copy: %w", err)
 	}
 
 	systemSHA256, err := calculateFileSHA256(systemTargetPath)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to hash system database: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to hash system database: %w", err)
 	}
 
 	snapshots = append(snapshots, SnapshotInfo{
@@ -1031,13 +1041,43 @@ func (dm *DatabaseManager) TakeSnapshotToDir(targetDir string) ([]SnapshotInfo, 
 	// Get max committed transaction ID (without lock since we already hold it)
 	maxTxnID := dm.getMaxCommittedTxnIDLocked()
 
+	// Read schema versions in this same locked section, immediately after the
+	// files above were checkpointed and copied, so the versions describe
+	// exactly the bytes being handed back to the caller.
+	schemaVersions := dm.schemaVersionsLocked()
+
 	log.Info().
 		Int("databases", len(snapshots)).
 		Uint64("max_txn_id", maxTxnID).
 		Str("target_dir", targetDir).
 		Msg("Snapshot copied to directory")
 
-	return snapshots, maxTxnID, nil
+	return snapshots, maxTxnID, schemaVersions, nil
+}
+
+// schemaVersionsLocked reads all schema versions from the system MetaStore.
+// Caller must hold dm.mu. Returns an empty map when the versions cannot be
+// read - the snapshot itself is still usable, the receiver simply has nothing
+// to restore and falls back to whatever it already knew.
+func (dm *DatabaseManager) schemaVersionsLocked() map[string]uint64 {
+	metaStore := dm.systemDB.GetMetaStore()
+	if metaStore == nil {
+		return nil
+	}
+
+	stored, err := metaStore.GetAllSchemaVersions()
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to read schema versions for snapshot")
+		return nil
+	}
+
+	versions := make(map[string]uint64, len(stored))
+	for database, version := range stored {
+		if version > 0 {
+			versions[database] = uint64(version)
+		}
+	}
+	return versions
 }
 
 // TakeSnapshotForDatabase creates a snapshot for a single database.

--- a/db/database_manager_test.go
+++ b/db/database_manager_test.go
@@ -963,7 +963,7 @@ func TestReplica_DoesNotReceiveSystemDBFromPrimary(t *testing.T) {
 	}
 
 	snapshotDir := filepath.Join(primaryDir, "snapshot")
-	snapshots, _, err := primaryDM.TakeSnapshotToDir(snapshotDir)
+	snapshots, _, _, err := primaryDM.TakeSnapshotToDir(snapshotDir)
 	if err != nil {
 		t.Fatalf("Failed to take snapshot: %v", err)
 	}
@@ -1044,6 +1044,60 @@ func TestReplica_DoesNotReceiveSystemDBFromPrimary(t *testing.T) {
 	}
 
 	t.Log("✓ Replica does not receive system DB from primary during snapshot")
+}
+
+// TakeSnapshotToDir must return the schema versions it read in the same
+// locked section that produced the copied files, so a caller streaming those
+// exact bytes later can advertise a version that actually matches them -
+// instead of a value read by an earlier, separate call that a concurrent DDL
+// commit could move past.
+func TestTakeSnapshotToDir_ReturnsSchemaVersionsCapturedWithFiles(t *testing.T) {
+	dm, tmpDir := setupTestDatabaseManager(t)
+	defer dm.Close()
+
+	if err := dm.CreateDatabase("appdb"); err != nil {
+		t.Fatalf("Failed to create appdb: %v", err)
+	}
+
+	systemMeta := dm.GetSystemDatabase().GetMetaStore()
+	if err := systemMeta.UpdateSchemaVersion("appdb", 5, "CREATE TABLE t(id INT)", 1); err != nil {
+		t.Fatalf("Failed to seed schema version: %v", err)
+	}
+
+	snapshotDir := filepath.Join(tmpDir, "snapshot")
+	_, _, schemaVersions, err := dm.TakeSnapshotToDir(snapshotDir)
+	if err != nil {
+		t.Fatalf("TakeSnapshotToDir failed: %v", err)
+	}
+
+	if got := schemaVersions["appdb"]; got != 5 {
+		t.Errorf("Expected schema version 5 for appdb, got %d", got)
+	}
+
+	// A version bumped AFTER the snapshot was taken must not appear in the
+	// already-returned map - it describes the files copied above, not
+	// whatever the live database does next.
+	if err := systemMeta.UpdateSchemaVersion("appdb", 6, "ALTER TABLE t ADD COLUMN x", 2); err != nil {
+		t.Fatalf("Failed to bump schema version after snapshot: %v", err)
+	}
+	if got := schemaVersions["appdb"]; got != 5 {
+		t.Errorf("Snapshot's schema versions map must not reflect a later change, got %d", got)
+	}
+}
+
+func TestTakeSnapshotToDir_NoSchemaVersionsIsEmptyMap(t *testing.T) {
+	dm, tmpDir := setupTestDatabaseManager(t)
+	defer dm.Close()
+
+	snapshotDir := filepath.Join(tmpDir, "snapshot")
+	_, _, schemaVersions, err := dm.TakeSnapshotToDir(snapshotDir)
+	if err != nil {
+		t.Fatalf("TakeSnapshotToDir failed: %v", err)
+	}
+
+	if len(schemaVersions) != 0 {
+		t.Errorf("Expected no schema versions for a database manager with no DDL applied, got %v", schemaVersions)
+	}
 }
 
 // TestReplica_SnapshotExcludesSystemDB tests that snapshot preparation excludes system DB for replicas

--- a/db/ddl_prepare_validate.go
+++ b/db/ddl_prepare_validate.go
@@ -5,12 +5,57 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 // isContextError reports whether err was caused by the context being cancelled or
 // timing out, rather than by the statement being invalid.
 func isContextError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// transientSQLiteCodes are primary SQLite result codes that describe a
+// resource or locking condition on this node right now, not a verdict on the
+// statement. With cache=shared, a table lock held by another connection in
+// this process (writeDB vs. hookDB) surfaces as SQLITE_LOCKED immediately -
+// busy_timeout does not apply to it, so the statement can fail here on pure
+// timing. A DDL that hits one of these must stay a retryable missing ACK: it
+// may succeed on retry, or once the condition clears.
+var transientSQLiteCodes = map[sqlite3.ErrNo]bool{
+	sqlite3.ErrBusy:     true, // SQLITE_BUSY: whole-file lock held by another connection/process
+	sqlite3.ErrLocked:   true, // SQLITE_LOCKED: table lock held by another connection, shared cache
+	sqlite3.ErrNomem:    true, // SQLITE_NOMEM: transient allocation failure
+	sqlite3.ErrIoErr:    true, // SQLITE_IOERR: transient disk I/O condition
+	sqlite3.ErrFull:     true, // SQLITE_FULL: disk or database full
+	sqlite3.ErrCantOpen: true, // SQLITE_CANTOPEN: could not open a required file
+	sqlite3.ErrProtocol: true, // SQLITE_PROTOCOL: locking protocol contention
+	sqlite3.ErrReadonly: true, // SQLITE_READONLY: database (or this connection) is read-only right now
+}
+
+// isDDLRejection reports whether err is a deterministic verdict on the DDL
+// statement itself - SQLite refuses to ever apply it, such as a constraint
+// violation or a schema conflict (duplicate column, missing table, syntax
+// error) - rather than a transient condition on this node such as lock
+// contention, a resource limit, or context cancellation.
+//
+// Only a rejection may be surfaced to the coordinator as a final refusal of
+// the transaction; everything else must stay a retryable missing ACK, exactly
+// as it was before DDL validation was added to PREPARE.
+func isDDLRejection(ctx context.Context, err error) bool {
+	if ctx.Err() != nil || isContextError(err) {
+		return false
+	}
+
+	var sqliteErr sqlite3.Error
+	if !errors.As(err, &sqliteErr) {
+		// Not a typed SQLite error - e.g. a wrapped BeginTx failure from
+		// connection-pool exhaustion. Treat conservatively as a missing ACK
+		// rather than assume it is a verdict on the statement.
+		return false
+	}
+
+	return !transientSQLiteCodes[sqliteErr.Code]
 }
 
 // ValidateDDLStatements verifies that DDL can be applied to this node before the

--- a/db/ddl_prepare_validate.go
+++ b/db/ddl_prepare_validate.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// isContextError reports whether err was caused by the context being cancelled or
+// timing out, rather than by the statement being invalid.
+func isContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// ValidateDDLStatements verifies that DDL can be applied to this node before the
+// participant ACKs PREPARE.
+//
+// PREPARE is the 2PC promise point: a node that ACKs it must be able to COMMIT.
+// SQLite reports most DDL failures (duplicate column, missing table, invalid
+// default) only when the statement executes, so the statements are executed here
+// inside a transaction that is always rolled back. Statements run in request
+// order so later DDL sees the schema produced by earlier DDL in the same
+// transaction.
+//
+// Statements are executed exactly as COMMIT will execute them, so callers must
+// pass the same SQL that will be applied - already rewritten for idempotency by
+// protocol.RewriteDDLForIdempotency - or validation and apply can disagree.
+//
+// The underlying SQLite error is returned unwrapped so callers can map it to the
+// matching MySQL error code.
+func ValidateDDLStatements(ctx context.Context, dbConn *sql.DB, statements []string) error {
+	if dbConn == nil || len(statements) == 0 {
+		return nil
+	}
+
+	tx, err := dbConn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin DDL validation transaction: %w", err)
+	}
+	// Always discard the validation transaction - it exists only to surface errors.
+	defer func() { _ = tx.Rollback() }()
+
+	for _, stmt := range statements {
+		if stmt == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/db/ddl_prepare_validate_test.go
+++ b/db/ddl_prepare_validate_test.go
@@ -1,0 +1,132 @@
+//go:build sqlite_preupdate_hook
+// +build sqlite_preupdate_hook
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func openDDLValidationDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open(SQLiteDriverName, ":memory:")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`CREATE TABLE groups (group_id INTEGER PRIMARY KEY, display_name TEXT, creation_date datetime)`)
+	require.NoError(t, err)
+	return db
+}
+
+func columnNames(t *testing.T, db *sql.DB, table string) []string {
+	t.Helper()
+	rows, err := db.Query(`SELECT name FROM pragma_table_info(?)`, table)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		names = append(names, name)
+	}
+	require.NoError(t, rows.Err())
+	return names
+}
+
+// A column that already exists must be rejected during PREPARE, not at COMMIT.
+func TestValidateDDLStatements_DuplicateColumn(t *testing.T) {
+	t.Parallel()
+	db := openDDLValidationDB(t)
+
+	err := ValidateDDLStatements(context.Background(), db, []string{
+		`ALTER TABLE groups ADD COLUMN creation_date datetime NOT NULL DEFAULT '2026-08-10 19:38:56.952152'`,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate column name: creation_date")
+}
+
+func TestValidateDDLStatements_MissingTable(t *testing.T) {
+	t.Parallel()
+	db := openDDLValidationDB(t)
+
+	err := ValidateDDLStatements(context.Background(), db, []string{
+		`ALTER TABLE missing_table ADD COLUMN x TEXT`,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no such table")
+}
+
+func TestValidateDDLStatements_ValidDDLLeavesNoSideEffects(t *testing.T) {
+	t.Parallel()
+	db := openDDLValidationDB(t)
+
+	require.NoError(t, ValidateDDLStatements(context.Background(), db, []string{
+		`ALTER TABLE groups ADD COLUMN uuid TEXT`,
+		`CREATE INDEX idx_groups_display_name ON groups(display_name)`,
+	}))
+
+	require.NotContains(t, columnNames(t, db, "groups"), "uuid")
+
+	var indexCount int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_groups_display_name'`).Scan(&indexCount))
+	require.Equal(t, 0, indexCount, "validation must roll back every statement it executes")
+}
+
+// Later statements must observe the schema produced by earlier ones so a
+// transaction that creates a table and then indexes it is not falsely rejected.
+func TestValidateDDLStatements_DependentStatements(t *testing.T) {
+	t.Parallel()
+	db := openDDLValidationDB(t)
+
+	require.NoError(t, ValidateDDLStatements(context.Background(), db, []string{
+		`CREATE TABLE memberships (id INTEGER PRIMARY KEY, group_id INTEGER)`,
+		`CREATE INDEX idx_memberships_group ON memberships(group_id)`,
+	}))
+}
+
+func TestValidateDDLStatements_FailureLeavesNoPartialSchema(t *testing.T) {
+	t.Parallel()
+	db := openDDLValidationDB(t)
+
+	err := ValidateDDLStatements(context.Background(), db, []string{
+		`ALTER TABLE groups ADD COLUMN uuid TEXT`,
+		`ALTER TABLE groups ADD COLUMN creation_date TEXT`,
+	})
+
+	require.Error(t, err)
+	require.NotContains(t, columnNames(t, db, "groups"), "uuid")
+}
+
+func TestValidateDDLStatements_NoStatements(t *testing.T) {
+	t.Parallel()
+	db := openDDLValidationDB(t)
+
+	require.NoError(t, ValidateDDLStatements(context.Background(), db, nil))
+	require.NoError(t, ValidateDDLStatements(context.Background(), db, []string{""}))
+	require.NoError(t, ValidateDDLStatements(context.Background(), nil, []string{`ALTER TABLE groups ADD COLUMN x TEXT`}))
+}
+
+// Validation must not hold the SQLite write connection once it returns, or the
+// COMMIT that follows PREPARE would block on a single-connection write pool.
+func TestValidateDDLStatements_ReleasesWriteConnection(t *testing.T) {
+	t.Parallel()
+	db := openDDLValidationDB(t)
+
+	err := ValidateDDLStatements(context.Background(), db, []string{
+		`ALTER TABLE groups ADD COLUMN creation_date TEXT`,
+	})
+	require.Error(t, err)
+
+	_, err = db.Exec(`ALTER TABLE groups ADD COLUMN uuid TEXT`)
+	require.NoError(t, err)
+	require.Contains(t, columnNames(t, db, "groups"), "uuid")
+}

--- a/db/ddl_prepare_validate_test.go
+++ b/db/ddl_prepare_validate_test.go
@@ -6,8 +6,13 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -129,4 +134,172 @@ func TestValidateDDLStatements_ReleasesWriteConnection(t *testing.T) {
 	_, err = db.Exec(`ALTER TABLE groups ADD COLUMN uuid TEXT`)
 	require.NoError(t, err)
 	require.Contains(t, columnNames(t, db, "groups"), "uuid")
+}
+
+// A genuine SQLite verdict on the statement - duplicate column - must be a
+// final rejection: retrying it can never succeed.
+func TestIsDDLRejection_DuplicateColumnIsRejected(t *testing.T) {
+	t.Parallel()
+	dbc := openDDLValidationDB(t)
+
+	err := ValidateDDLStatements(context.Background(), dbc, []string{
+		`ALTER TABLE groups ADD COLUMN creation_date datetime NOT NULL DEFAULT '2026-08-10 19:38:56.952152'`,
+	})
+	require.Error(t, err)
+
+	var sqliteErr sqlite3.Error
+	require.True(t, errors.As(err, &sqliteErr), "expected a typed sqlite3.Error, got %T: %v", err, err)
+	require.True(t, isDDLRejection(context.Background(), err))
+}
+
+// A genuine SQLite verdict on the statement - missing table - must be a final
+// rejection.
+func TestIsDDLRejection_MissingTableIsRejected(t *testing.T) {
+	t.Parallel()
+	dbc := openDDLValidationDB(t)
+
+	err := ValidateDDLStatements(context.Background(), dbc, []string{
+		`ALTER TABLE missing_table ADD COLUMN x TEXT`,
+	})
+	require.Error(t, err)
+	require.True(t, isDDLRejection(context.Background(), err))
+}
+
+// A cancelled validation says nothing about the DDL and must never be a
+// rejection.
+func TestIsDDLRejection_ContextCanceledIsNotRejected(t *testing.T) {
+	t.Parallel()
+	dbc := openDDLValidationDB(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := ValidateDDLStatements(ctx, dbc, []string{`ALTER TABLE groups ADD COLUMN x TEXT`})
+	require.Error(t, err)
+	// Premise: this really is a context error, not some other failure that
+	// happens to occur after cancellation.
+	require.True(t, isContextError(err), "premise failed: err is not a context error: %v", err)
+
+	require.False(t, isDDLRejection(ctx, err))
+}
+
+// A validation that times out says nothing about the DDL and must never be a
+// rejection - this is the case the added DDL validation timeout exists to make
+// survivable rather than a hard PREPARE failure.
+func TestIsDDLRejection_DeadlineExceededIsNotRejected(t *testing.T) {
+	t.Parallel()
+	dbc := openDDLValidationDB(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond)
+
+	err := ValidateDDLStatements(ctx, dbc, []string{`ALTER TABLE groups ADD COLUMN x TEXT`})
+	require.Error(t, err)
+	require.True(t, isContextError(err), "premise failed: err is not a context error: %v", err)
+
+	require.False(t, isDDLRejection(ctx, err))
+}
+
+// An error that is not a typed SQLite error - for example connection-pool
+// exhaustion wrapped around BeginTx - carries no verdict on the statement and
+// must stay retryable rather than being assumed to be a rejection.
+func TestIsDDLRejection_NonSQLiteErrorIsNotRejected(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("failed to begin DDL validation transaction: %w", errors.New("pool exhausted"))
+
+	var sqliteErr sqlite3.Error
+	require.False(t, errors.As(err, &sqliteErr), "premise failed: err unexpectedly is a typed sqlite3.Error")
+
+	require.False(t, isDDLRejection(context.Background(), err))
+}
+
+// SQLite table locks are the reachable, real-world case a transient
+// classification protects: with cache=shared, hookDB and writeDB are separate
+// connections in the same process (see db_integration.go), and a table lock
+// hookDB holds surfaces to writeDB as SQLITE_LOCKED immediately - busy_timeout
+// does not apply to it. This must stay a retryable missing ACK, not a
+// rejection: DDL colliding with an in-flight DML on the same table is routine,
+// not a verdict that the DDL can never be applied.
+func TestIsDDLRejection_SharedCacheLockedIsNotRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dsn := "file:" + filepath.Join(dir, "lock.db") + "?_journal_mode=WAL&_busy_timeout=5000&_txlock=immediate&cache=shared"
+
+	// connA mimics hookDB: a separate connection on the same shared cache that
+	// holds a write lock on the table the DDL below targets.
+	connA, err := sql.Open(SQLiteDriverName, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { connA.Close() })
+	connA.SetMaxOpenConns(1)
+
+	// connB mimics writeDB: the connection ValidateDDLStatements runs on.
+	connB, err := sql.Open(SQLiteDriverName, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { connB.Close() })
+	connB.SetMaxOpenConns(1)
+
+	_, err = connB.Exec(`CREATE TABLE locked_t (id INTEGER PRIMARY KEY, val TEXT)`)
+	require.NoError(t, err)
+
+	tx, err := connA.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	_, err = tx.ExecContext(context.Background(), `INSERT INTO locked_t (id, val) VALUES (1, 'x')`)
+	require.NoError(t, err)
+
+	start := time.Now()
+	verr := ValidateDDLStatements(context.Background(), connB, []string{`ALTER TABLE locked_t ADD COLUMN extra TEXT`})
+	elapsed := time.Since(start)
+
+	require.Error(t, verr)
+	// Premise: SQLITE_LOCKED fails immediately and does not wait out
+	// _busy_timeout=5000ms - if it did, this scenario would be indistinguishable
+	// from SQLITE_BUSY and the whole rationale for a typed-code classification
+	// over blanket "not a context error" would not hold.
+	require.Less(t, elapsed, 2*time.Second, "premise failed: SQLITE_LOCKED waited out busy_timeout")
+
+	var sqliteErr sqlite3.Error
+	require.True(t, errors.As(verr, &sqliteErr), "expected a typed sqlite3.Error, got %T: %v", verr, verr)
+	require.Equal(t, sqlite3.ErrLocked, sqliteErr.Code,
+		"expected SQLITE_LOCKED - if this fires as SQLITE_BUSY instead, the shared-cache premise needs re-checking")
+
+	require.False(t, isDDLRejection(context.Background(), verr),
+		"a shared-cache lock is a transient condition on this node, not a verdict on the DDL")
+}
+
+// A read-only database is a condition on this node - e.g. this replica's file
+// is mounted read-only, or a prior connection put it in query-only mode - not
+// a verdict on the DDL statement itself: the same statement applies cleanly on
+// a writable node. This must stay a retryable missing ACK, not a rejection.
+func TestIsDDLRejection_ReadonlyIsNotRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dsn := "file:" + filepath.Join(dir, "readonly.db") + "?_journal_mode=WAL"
+
+	setup, err := sql.Open(SQLiteDriverName, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { setup.Close() })
+	_, err = setup.Exec(`CREATE TABLE groups (group_id INTEGER PRIMARY KEY, display_name TEXT)`)
+	require.NoError(t, err)
+	require.NoError(t, setup.Close())
+
+	roConn, err := sql.Open(SQLiteDriverName, dsn+"&mode=ro")
+	require.NoError(t, err)
+	t.Cleanup(func() { roConn.Close() })
+	roConn.SetMaxOpenConns(1)
+
+	verr := ValidateDDLStatements(context.Background(), roConn, []string{`ALTER TABLE groups ADD COLUMN extra TEXT`})
+	require.Error(t, verr)
+
+	var sqliteErr sqlite3.Error
+	require.True(t, errors.As(verr, &sqliteErr), "expected a typed sqlite3.Error, got %T: %v", verr, verr)
+	require.Equal(t, sqlite3.ErrReadonly, sqliteErr.Code,
+		"expected SQLITE_READONLY - if this fires as a different code, the mode=ro premise needs re-checking")
+
+	require.False(t, isDDLRejection(context.Background(), verr),
+		"a read-only database is a condition on this node, not a verdict on the DDL")
 }

--- a/db/replication_engine.go
+++ b/db/replication_engine.go
@@ -34,6 +34,10 @@ type PrepareResult struct {
 	Error            string
 	ConflictDetected bool
 	ConflictDetails  string
+	// Rejected marks a deterministic refusal of the statement itself, such as DDL
+	// SQLite cannot apply. Infrastructure failures (timeouts, storage errors) leave
+	// it false so the coordinator keeps treating them as a missing ACK.
+	Rejected bool
 }
 
 // CommitRequest contains parameters for the commit phase
@@ -79,7 +83,21 @@ func (re *ReplicationEngine) Prepare(ctx context.Context, req *PrepareRequest) *
 		return re.prepareDatabaseOperation(req)
 	}
 
-	return re.prepareRegularTransaction(req)
+	return re.prepareRegularTransaction(ctx, req)
+}
+
+// ddlStatementsToValidate collects the DDL SQL that COMMIT will execute, in
+// request order. Vector index control and LOAD DATA reuse the DDL intent type but
+// are applied through their own paths, so they are excluded.
+func ddlStatementsToValidate(statements []protocol.Statement) []string {
+	var ddlSQL []string
+	for _, stmt := range statements {
+		if stmt.Type != protocol.StatementDDL || stmt.SQL == "" {
+			continue
+		}
+		ddlSQL = append(ddlSQL, stmt.SQL)
+	}
+	return ddlSQL
 }
 
 // isDatabaseOperation checks if the request contains a CREATE/DROP DATABASE statement
@@ -150,7 +168,7 @@ func (re *ReplicationEngine) prepareDatabaseOperation(req *PrepareRequest) *Prep
 }
 
 // prepareRegularTransaction handles regular transaction preparation
-func (re *ReplicationEngine) prepareRegularTransaction(req *PrepareRequest) *PrepareResult {
+func (re *ReplicationEngine) prepareRegularTransaction(ctx context.Context, req *PrepareRequest) *PrepareResult {
 	replicatedDB, err := re.dbMgr.GetDatabase(req.Database)
 	if err != nil {
 		return &PrepareResult{Success: false, Error: fmt.Sprintf("database not found: %s", req.Database)}
@@ -158,6 +176,29 @@ func (re *ReplicationEngine) prepareRegularTransaction(req *PrepareRequest) *Pre
 
 	txnMgr := replicatedDB.GetTransactionManager()
 	metaStore := replicatedDB.GetMetaStore()
+
+	// DDL is only executed during COMMIT, so validate it up front: a participant
+	// that ACKs PREPARE must be able to commit. Without this, invalid DDL fails
+	// after peers have committed and leaves the cluster inconsistent.
+	//
+	// Statements are validated together, in order, because an explicit client
+	// transaction can carry several DDL statements where a later one depends on
+	// the schema an earlier one creates.
+	if ddlSQL := ddlStatementsToValidate(req.Statements); len(ddlSQL) > 0 {
+		if err := txnMgr.ValidateDDL(ctx, ddlSQL); err != nil {
+			// Only a verdict on the statement itself is a rejection. A cancelled or
+			// timed-out validation says nothing about the DDL, so it must stay a
+			// missing ACK the coordinator can retry rather than a final answer.
+			rejected := ctx.Err() == nil && !isContextError(err)
+			log.Debug().
+				Err(err).
+				Uint64("txn_id", req.TxnID).
+				Uint64("node_id", re.nodeID).
+				Bool("rejected", rejected).
+				Msg("DDL validation failed during PREPARE")
+			return &PrepareResult{Success: false, Error: err.Error(), Rejected: rejected}
+		}
+	}
 
 	txn, err := txnMgr.BeginTransactionWithID(req.TxnID, req.NodeID, req.StartTS)
 	if err != nil {
@@ -522,6 +563,7 @@ func (pr *PrepareResult) ToCoordinatorResponse() *coordinator.ReplicationRespons
 		Error:            pr.Error,
 		ConflictDetected: pr.ConflictDetected,
 		ConflictDetails:  pr.ConflictDetails,
+		Rejected:         pr.Rejected,
 	}
 }
 

--- a/db/replication_engine.go
+++ b/db/replication_engine.go
@@ -187,9 +187,11 @@ func (re *ReplicationEngine) prepareRegularTransaction(ctx context.Context, req 
 	if ddlSQL := ddlStatementsToValidate(req.Statements); len(ddlSQL) > 0 {
 		if err := txnMgr.ValidateDDL(ctx, ddlSQL); err != nil {
 			// Only a verdict on the statement itself is a rejection. A cancelled or
-			// timed-out validation says nothing about the DDL, so it must stay a
-			// missing ACK the coordinator can retry rather than a final answer.
-			rejected := ctx.Err() == nil && !isContextError(err)
+			// timed-out validation, or a transient SQLite condition such as a
+			// shared-cache lock race with hookDB (SQLITE_LOCKED, SQLITE_BUSY), says
+			// nothing about the DDL, so it must stay a missing ACK the coordinator
+			// can retry rather than a final answer.
+			rejected := isDDLRejection(ctx, err)
 			log.Debug().
 				Err(err).
 				Uint64("txn_id", req.TxnID).

--- a/db/replication_engine_test.go
+++ b/db/replication_engine_test.go
@@ -846,3 +846,159 @@ func TestReplicationEngine_ClockUpdate(t *testing.T) {
 	assert.Greater(t, updatedTime.WallTime, initialTime.WallTime, "Clock should be updated")
 	assert.GreaterOrEqual(t, updatedTime.WallTime, futureTS.WallTime, "Clock should advance to at least the request timestamp")
 }
+
+// TestReplicationEngine_PrepareRejectsInvalidDDL verifies that DDL SQLite cannot
+// apply is rejected during PREPARE. PREPARE is the 2PC promise point: accepting
+// such a statement makes COMMIT fail after peers have already committed.
+func TestReplicationEngine_PrepareRejectsInvalidDDL(t *testing.T) {
+	engine, dm, cleanup := setupTestReplicationEngine(t)
+	defer cleanup()
+
+	require.NoError(t, dm.CreateDatabase("testdb"))
+	replicatedDB, err := dm.GetDatabase("testdb")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	createReq := &PrepareRequest{
+		TxnID:    2001,
+		NodeID:   1,
+		StartTS:  hlc.Timestamp{WallTime: 1000, Logical: 1},
+		Database: "testdb",
+		Statements: []protocol.Statement{{
+			Type:      protocol.StatementDDL,
+			SQL:       "CREATE TABLE groups (group_id INTEGER PRIMARY KEY, creation_date datetime)",
+			TableName: "groups",
+		}},
+	}
+	require.True(t, engine.Prepare(ctx, createReq).Success)
+	commitResult := engine.Commit(ctx, &CommitRequest{
+		TxnID:      2001,
+		Database:   "testdb",
+		Statements: createReq.Statements,
+	})
+	require.True(t, commitResult.Success, "setup commit failed: %s", commitResult.Error)
+
+	// Adding an existing column can never commit - PREPARE must reject it.
+	dupReq := &PrepareRequest{
+		TxnID:    2002,
+		NodeID:   1,
+		StartTS:  hlc.Timestamp{WallTime: 2000, Logical: 1},
+		Database: "testdb",
+		Statements: []protocol.Statement{{
+			Type:      protocol.StatementDDL,
+			SQL:       "ALTER TABLE groups ADD COLUMN creation_date datetime NOT NULL DEFAULT '2026-08-10 19:38:56'",
+			TableName: "groups",
+		}},
+	}
+
+	result := engine.Prepare(ctx, dupReq)
+
+	require.False(t, result.Success, "PREPARE must reject DDL that cannot be applied")
+	require.Contains(t, result.Error, "duplicate column name: creation_date")
+
+	// A rejected PREPARE must not leave transaction or intent state behind.
+	metaStore := replicatedDB.GetMetaStore()
+	intents, err := metaStore.GetIntentsByTxn(2002)
+	require.NoError(t, err)
+	require.Empty(t, intents, "rejected DDL must not create write intents")
+	require.Nil(t, replicatedDB.GetTransactionManager().GetTransaction(2002),
+		"rejected DDL must not leave a pending transaction")
+
+	// The database must be untouched and still usable for valid DDL.
+	validReq := &PrepareRequest{
+		TxnID:    2003,
+		NodeID:   1,
+		StartTS:  hlc.Timestamp{WallTime: 3000, Logical: 1},
+		Database: "testdb",
+		Statements: []protocol.Statement{{
+			Type:      protocol.StatementDDL,
+			SQL:       "ALTER TABLE groups ADD COLUMN uuid TEXT",
+			TableName: "groups",
+		}},
+	}
+	require.True(t, engine.Prepare(ctx, validReq).Success, "valid DDL must still prepare")
+}
+
+// TestReplicationEngine_PrepareValidatesDependentDDL verifies that DDL depending
+// on an earlier statement in the same transaction is not falsely rejected.
+func TestReplicationEngine_PrepareValidatesDependentDDL(t *testing.T) {
+	engine, dm, cleanup := setupTestReplicationEngine(t)
+	defer cleanup()
+
+	require.NoError(t, dm.CreateDatabase("testdb"))
+
+	result := engine.Prepare(context.Background(), &PrepareRequest{
+		TxnID:    2101,
+		NodeID:   1,
+		StartTS:  hlc.Timestamp{WallTime: 1000, Logical: 1},
+		Database: "testdb",
+		Statements: []protocol.Statement{
+			{
+				Type:      protocol.StatementDDL,
+				SQL:       "CREATE TABLE memberships (id INTEGER PRIMARY KEY, group_id INTEGER)",
+				TableName: "memberships",
+			},
+			{
+				Type:      protocol.StatementDDL,
+				SQL:       "CREATE INDEX idx_memberships_group ON memberships(group_id)",
+				TableName: "memberships",
+			},
+		},
+	})
+
+	require.True(t, result.Success, "dependent DDL must prepare: %s", result.Error)
+}
+
+// TestReplicationEngine_PrepareCancelledDDLIsNotRejection verifies that a
+// validation that could not finish is reported as a plain failure, never as a
+// rejection. Only a verdict on the statement itself may be final: a timeout says
+// nothing about whether the DDL is applicable.
+func TestReplicationEngine_PrepareCancelledDDLIsNotRejection(t *testing.T) {
+	engine, dm, cleanup := setupTestReplicationEngine(t)
+	defer cleanup()
+
+	require.NoError(t, dm.CreateDatabase("testdb"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result := engine.Prepare(ctx, &PrepareRequest{
+		TxnID:    2201,
+		NodeID:   1,
+		StartTS:  hlc.Timestamp{WallTime: 1000, Logical: 1},
+		Database: "testdb",
+		Statements: []protocol.Statement{{
+			Type:      protocol.StatementDDL,
+			SQL:       "CREATE TABLE cancelled_t (id INTEGER PRIMARY KEY)",
+			TableName: "cancelled_t",
+		}},
+	})
+
+	require.False(t, result.Success, "cancelled validation must not report success")
+	require.False(t, result.Rejected, "a cancelled validation is not a rejection of the statement")
+}
+
+// A statement SQLite refuses is a final verdict and must be marked as such.
+func TestReplicationEngine_PrepareInvalidDDLIsRejection(t *testing.T) {
+	engine, dm, cleanup := setupTestReplicationEngine(t)
+	defer cleanup()
+
+	require.NoError(t, dm.CreateDatabase("testdb"))
+
+	result := engine.Prepare(context.Background(), &PrepareRequest{
+		TxnID:    2202,
+		NodeID:   1,
+		StartTS:  hlc.Timestamp{WallTime: 1000, Logical: 1},
+		Database: "testdb",
+		Statements: []protocol.Statement{{
+			Type:      protocol.StatementDDL,
+			SQL:       "ALTER TABLE missing_table ADD COLUMN x TEXT",
+			TableName: "missing_table",
+		}},
+	})
+
+	require.False(t, result.Success)
+	require.True(t, result.Rejected, "invalid DDL must be a final rejection")
+	require.True(t, result.ToCoordinatorResponse().Rejected, "rejection must survive the coordinator conversion")
+}

--- a/db/replication_engine_test.go
+++ b/db/replication_engine_test.go
@@ -3,7 +3,9 @@ package db
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/maxpert/marmot/cfg"
 	"github.com/maxpert/marmot/encoding"
 	"github.com/maxpert/marmot/hlc"
 	"github.com/maxpert/marmot/protocol"
@@ -1001,4 +1003,94 @@ func TestReplicationEngine_PrepareInvalidDDLIsRejection(t *testing.T) {
 	require.False(t, result.Success)
 	require.True(t, result.Rejected, "invalid DDL must be a final rejection")
 	require.True(t, result.ToCoordinatorResponse().Rejected, "rejection must survive the coordinator conversion")
+}
+
+// A DDL that loses a lock race against a concurrent DML on the same table via
+// hookDB must not be treated as a final rejection.
+//
+// db_integration.go documents writeDB and hookDB as sharing one SQLite page
+// cache via "cache=shared" so contention between them surfaces as immediate
+// SQLITE_LOCKED. In practice the DSN mattn's driver receives here is a plain
+// filesystem path with no "file:" scheme prefix, and the driver only forwards
+// query parameters (including cache=shared) to SQLite when the DSN starts
+// with "file:" - otherwise it strips them before opening
+// (github.com/mattn/go-sqlite3@v1.14.24/sqlite3.go:1450). So cache=shared is
+// silently dropped today, and contention between the two connections is an
+// ordinary whole-file SQLITE_BUSY bounded by busy_timeout, not SQLITE_LOCKED.
+// Confirmed empirically: with the exact DSN shape db_integration.go builds,
+// the error is "database is locked" with Code=sqlite3.ErrBusy, not
+// "database table is locked" with Code=sqlite3.ErrLocked. This is a
+// pre-existing gap in db_integration.go, outside this fix's scope; it is
+// exercised here, not fixed, because it changes what this test must prove.
+// Either way the classifier must not reject: SQLITE_BUSY is transient too.
+func TestReplicationEngine_PrepareHookDBLockContentionIsNotRejection(t *testing.T) {
+	// Shrink the busy-wait window so the test doesn't block for the default
+	// 50s lock_wait_timeout_seconds while still forcing a real wait long
+	// enough to prove genuine contention, not a fluke.
+	originalTimeout := cfg.Config.Transaction.LockWaitTimeoutSeconds
+	cfg.Config.Transaction.LockWaitTimeoutSeconds = 1
+	t.Cleanup(func() { cfg.Config.Transaction.LockWaitTimeoutSeconds = originalTimeout })
+
+	engine, dm, cleanup := setupTestReplicationEngine(t)
+	defer cleanup()
+
+	require.NoError(t, dm.CreateDatabase("testdb"))
+	replicatedDB, err := dm.GetDatabase("testdb")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	createReq := &PrepareRequest{
+		TxnID:    2301,
+		NodeID:   1,
+		StartTS:  hlc.Timestamp{WallTime: 1000, Logical: 1},
+		Database: "testdb",
+		Statements: []protocol.Statement{{
+			Type:      protocol.StatementDDL,
+			SQL:       "CREATE TABLE locked_t (id INTEGER PRIMARY KEY, val TEXT)",
+			TableName: "locked_t",
+		}},
+	}
+	require.True(t, engine.Prepare(ctx, createReq).Success)
+	commitResult := engine.Commit(ctx, &CommitRequest{
+		TxnID:      2301,
+		Database:   "testdb",
+		Statements: createReq.Statements,
+	})
+	require.True(t, commitResult.Success, "setup commit failed: %s", commitResult.Error)
+
+	// Hold a write lock on locked_t via hookDB - the same connection
+	// ExecuteLocalWithHooks uses for CDC capture - to reproduce the real
+	// production race rather than a synthetic stand-in.
+	hookTx, err := replicatedDB.hookDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = hookTx.Rollback() })
+	_, err = hookTx.ExecContext(ctx, "INSERT INTO locked_t (id, val) VALUES (1, 'x')")
+	require.NoError(t, err)
+
+	start := time.Now()
+	ddlReq := &PrepareRequest{
+		TxnID:    2302,
+		NodeID:   1,
+		StartTS:  hlc.Timestamp{WallTime: 2000, Logical: 1},
+		Database: "testdb",
+		Statements: []protocol.Statement{{
+			Type:      protocol.StatementDDL,
+			SQL:       "ALTER TABLE locked_t ADD COLUMN extra TEXT",
+			TableName: "locked_t",
+		}},
+	}
+	result := engine.Prepare(ctx, ddlReq)
+	elapsed := time.Since(start)
+
+	require.False(t, result.Success, "DDL contending for the hookDB lock must not succeed while the lock is held")
+	// Premise: the failure actually is lock contention with hookDB, not some
+	// unrelated failure, and it genuinely waited out busy_timeout rather than
+	// failing for a different reason entirely.
+	require.Contains(t, result.Error, "locked", "premise failed: expected a lock-contention failure")
+	require.GreaterOrEqual(t, elapsed, 900*time.Millisecond, "premise failed: did not wait out busy_timeout - contention was not provoked")
+	require.Less(t, elapsed, 5*time.Second, "premise failed: took far longer than the 1s busy_timeout budget")
+
+	require.False(t, result.Rejected,
+		"lock contention on this node is a transient condition, not a verdict on the DDL - it must stay a retryable missing ACK")
 }

--- a/db/schema_version_restore.go
+++ b/db/schema_version_restore.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
+// RestoreSchemaVersions records schema versions carried by a snapshot into the
+// system MetaStore, where schema versions are tracked.
+//
+// Snapshots transfer SQLite files only, so a receiver that does not restore these
+// keeps reporting version 0 and then refuses every transaction stamped with a
+// higher required schema version - including plain DML. That state never heals on
+// its own, because the only way to advance the version is committing a DDL
+// transaction the node can no longer take part in.
+//
+// A database is never moved backwards: the node may have applied DDL after the
+// snapshot was taken.
+func RestoreSchemaVersions(metaStore MetaStore, versions map[string]uint64) error {
+	if metaStore == nil || len(versions) == 0 {
+		return nil
+	}
+
+	for database, version := range versions {
+		if database == "" || version == 0 {
+			continue
+		}
+
+		current, err := metaStore.GetSchemaVersion(database)
+		if err != nil {
+			return fmt.Errorf("failed to read schema version for %s: %w", database, err)
+		}
+		if current >= int64(version) {
+			continue
+		}
+
+		if err := metaStore.UpdateSchemaVersion(database, int64(version), "", 0); err != nil {
+			return fmt.Errorf("failed to restore schema version for %s: %w", database, err)
+		}
+
+		log.Info().
+			Str("database", database).
+			Int64("previous_version", current).
+			Uint64("restored_version", version).
+			Msg("Restored schema version from snapshot")
+	}
+
+	return nil
+}

--- a/db/schema_version_restore_test.go
+++ b/db/schema_version_restore_test.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newRestoreTestMetaStore(t *testing.T) MetaStore {
+	t.Helper()
+
+	metaStore, err := NewPebbleMetaStore(t.TempDir(), PebbleMetaStoreOptions{
+		CacheSizeMB:           16,
+		MemTableSizeMB:        16,
+		MemTableCount:         2,
+		L0CompactionThreshold: 4,
+		L0StopWrites:          12,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { metaStore.Close() })
+	return metaStore
+}
+
+func TestRestoreSchemaVersions(t *testing.T) {
+	t.Parallel()
+	metaStore := newRestoreTestMetaStore(t)
+
+	require.NoError(t, RestoreSchemaVersions(metaStore, map[string]uint64{"appdb": 17, "otherdb": 3}))
+
+	version, err := metaStore.GetSchemaVersion("appdb")
+	require.NoError(t, err)
+	require.Equal(t, int64(17), version)
+
+	version, err = metaStore.GetSchemaVersion("otherdb")
+	require.NoError(t, err)
+	require.Equal(t, int64(3), version)
+}
+
+// A node that applied DDL after the snapshot was taken must not be rewound: that
+// would make it refuse transactions it is actually able to serve.
+func TestRestoreSchemaVersionsNeverGoesBackwards(t *testing.T) {
+	t.Parallel()
+	metaStore := newRestoreTestMetaStore(t)
+
+	require.NoError(t, metaStore.UpdateSchemaVersion("appdb", 20, "", 0))
+	require.NoError(t, RestoreSchemaVersions(metaStore, map[string]uint64{"appdb": 17}))
+
+	version, err := metaStore.GetSchemaVersion("appdb")
+	require.NoError(t, err)
+	require.Equal(t, int64(20), version)
+}
+
+func TestRestoreSchemaVersionsIgnoresEmptyInput(t *testing.T) {
+	t.Parallel()
+	metaStore := newRestoreTestMetaStore(t)
+
+	require.NoError(t, RestoreSchemaVersions(metaStore, nil))
+	require.NoError(t, RestoreSchemaVersions(nil, map[string]uint64{"appdb": 4}))
+	require.NoError(t, RestoreSchemaVersions(metaStore, map[string]uint64{"": 4, "appdb": 0}))
+
+	versions, err := metaStore.GetAllSchemaVersions()
+	require.NoError(t, err)
+	require.Empty(t, versions)
+}
+
+// The restored version must be what a subsequent PREPARE compares against, which
+// is what SchemaVersionManager reads.
+func TestRestoreSchemaVersionsVisibleToSchemaVersionManager(t *testing.T) {
+	t.Parallel()
+	metaStore := newRestoreTestMetaStore(t)
+
+	require.NoError(t, RestoreSchemaVersions(metaStore, map[string]uint64{"appdb": 17}))
+
+	version, err := NewSchemaVersionManager(metaStore).GetSchemaVersion("appdb")
+	require.NoError(t, err)
+	require.Equal(t, uint64(17), version, "a restored node must not report itself behind the cluster")
+}

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -202,6 +202,13 @@ func (tm *TransactionManager) BeginTransactionWithID(txnID, nodeID uint64, start
 	return txn, nil
 }
 
+// ValidateDDL checks that the given DDL statements can be applied to this node's
+// database without leaving any side effects. Called during PREPARE so a node
+// never promises to commit DDL that SQLite would reject at COMMIT time.
+func (tm *TransactionManager) ValidateDDL(ctx context.Context, statements []string) error {
+	return ValidateDDLStatements(ctx, tm.db, statements)
+}
+
 // AddStatement adds a statement to the transaction buffer
 func (tm *TransactionManager) AddStatement(txn *Transaction, stmt protocol.Statement) error {
 	txn.mu.Lock()

--- a/grpc/catch_up.go
+++ b/grpc/catch_up.go
@@ -3,10 +3,12 @@ package grpc
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/maxpert/marmot/cfg"
@@ -34,6 +36,16 @@ type CatchUpClient struct {
 	dataDir   string
 	registry  *NodeRegistry
 	seedAddrs []string
+
+	// dbManager is set once the DatabaseManager exists (after the startup join
+	// path completes). Anti-entropy snapshot repairs run at runtime, long after
+	// NewDatabaseManager has opened the system MetaStore on this same dataDir -
+	// so restoring schema versions must write through that live store instead
+	// of opening a second handle on the same Pebble directory, which deadlocks
+	// against Pebble's per-process exclusive lock. nil during the startup join
+	// path, where no DatabaseManager exists yet and the MetaStore is opened
+	// directly by path.
+	dbManager atomic.Pointer[db.DatabaseManager]
 }
 
 // NewCatchUpClient creates a new catch-up client
@@ -44,6 +56,50 @@ func NewCatchUpClient(nodeID uint64, dataDir string, registry *NodeRegistry, see
 		registry:  registry,
 		seedAddrs: seedAddrs,
 	}
+}
+
+// SetDatabaseManager wires the live DatabaseManager once it exists, so runtime
+// snapshot restores (anti-entropy) write schema versions through the
+// already-open system MetaStore rather than opening a second handle on the
+// same Pebble directory. Must be called before anti-entropy starts invoking
+// CatchUpFromPeer.
+func (c *CatchUpClient) SetDatabaseManager(dbMgr *db.DatabaseManager) {
+	c.dbManager.Store(dbMgr)
+}
+
+// persistSchemaVersions restores a snapshot's schema versions, writing through
+// the live DatabaseManager's system MetaStore when one is available (the
+// anti-entropy runtime path), or by opening the MetaStore directly by path
+// when it is not (the startup join path, before the DatabaseManager exists).
+func (c *CatchUpClient) persistSchemaVersions(versions map[string]uint64) error {
+	if dbMgr := c.dbManager.Load(); dbMgr != nil {
+		return persistSnapshotSchemaVersionsViaManager(dbMgr, versions)
+	}
+	return persistSnapshotSchemaVersions(c.dataDir, versions)
+}
+
+// SchemaVersionRestoreError indicates that a snapshot's database files were
+// already swapped onto disk before restoring its schema versions failed. A
+// caller that reopens database connections only on success must still reopen
+// them when it sees this error: the files changed underneath the old
+// connection regardless of whether the schema version could be recorded.
+type SchemaVersionRestoreError struct {
+	err error
+}
+
+func (e *SchemaVersionRestoreError) Error() string { return e.err.Error() }
+func (e *SchemaVersionRestoreError) Unwrap() error { return e.err }
+
+// FilesSwappedDespiteError reports whether err indicates that a snapshot's
+// database files were already swapped onto disk, even though the overall
+// catch-up operation failed. Callers must still reopen database connections in
+// that case, or they keep serving stale connections against fresh files.
+func FilesSwappedDespiteError(err error) bool {
+	if err == nil {
+		return true
+	}
+	var schemaErr *SchemaVersionRestoreError
+	return errors.As(err, &schemaErr)
 }
 
 // CatchUpFromPeer downloads a snapshot of a specific database from a peer
@@ -240,11 +296,18 @@ func (c *CatchUpClient) applySnapshot(ctx context.Context, client MarmotServiceC
 		return fmt.Errorf("snapshot restore failed: %w", err)
 	}
 
-	// Restore the schema versions the snapshot was taken at. Skipping this leaves
-	// the node reporting version 0, after which it refuses every transaction that
-	// requires a newer schema and can never rejoin replication.
-	if err := persistSnapshotSchemaVersions(c.dataDir, info.DatabaseMetadata); err != nil {
-		return fmt.Errorf("failed to restore schema versions from snapshot: %w", err)
+	// From this point on the snapshot's files are already swapped onto disk.
+	// Restore the schema versions the snapshot was taken at - skipping this
+	// leaves the node reporting version 0, after which it refuses every
+	// transaction that requires a newer schema and can never rejoin
+	// replication. Prefer the versions captured atomically with these exact
+	// files (the stream trailer) over the earlier, potentially stale read from
+	// GetSnapshotInfo.
+	versions := SnapshotVersionsForRestore(info.DatabaseMetadata, stream)
+	if err := c.persistSchemaVersions(versions); err != nil {
+		return &SchemaVersionRestoreError{
+			err: fmt.Errorf("failed to restore schema versions from snapshot: %w", err),
+		}
 	}
 
 	log.Info().

--- a/grpc/catch_up.go
+++ b/grpc/catch_up.go
@@ -240,6 +240,13 @@ func (c *CatchUpClient) applySnapshot(ctx context.Context, client MarmotServiceC
 		return fmt.Errorf("snapshot restore failed: %w", err)
 	}
 
+	// Restore the schema versions the snapshot was taken at. Skipping this leaves
+	// the node reporting version 0, after which it refuses every transaction that
+	// requires a newer schema and can never rejoin replication.
+	if err := persistSnapshotSchemaVersions(c.dataDir, info.DatabaseMetadata); err != nil {
+		return fmt.Errorf("failed to restore schema versions from snapshot: %w", err)
+	}
+
 	log.Info().
 		Uint64("snapshot_txn_id", info.SnapshotTxnId).
 		Msg("Snapshot applied successfully via unified restorer")

--- a/grpc/catch_up_test.go
+++ b/grpc/catch_up_test.go
@@ -1,11 +1,21 @@
 package grpc
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
 	"testing"
 
 	"github.com/maxpert/marmot/cfg"
+	"github.com/maxpert/marmot/db"
+	"github.com/maxpert/marmot/hlc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 // TestDetermineCatchUpStrategy_UsesConfigThreshold verifies that the catch-up strategy
@@ -261,4 +271,119 @@ func TestCatchUpDecision_FieldsPopulated(t *testing.T) {
 	assert.Equal(t, uint64(100), delta.LocalTxnID)
 	assert.Equal(t, uint64(200), delta.PeerTxnID)
 	assert.Equal(t, uint64(100), delta.TxnsBehind)
+}
+
+// Before a DatabaseManager is wired in (the startup join path), schema
+// versions must be persisted by opening the MetaStore directly by path -
+// there is nothing else running yet to hold it open.
+func TestCatchUpClient_PersistSchemaVersions_NoManagerUsesPath(t *testing.T) {
+	dataDir := t.TempDir()
+	registry := NewNodeRegistry(1, "localhost:5001")
+	client := NewCatchUpClient(1, dataDir, registry, nil)
+
+	require.NoError(t, client.persistSchemaVersions(map[string]uint64{"appdb": 6}))
+
+	require.Equal(t, int64(6), readSchemaVersions(t, dataDir)["appdb"])
+}
+
+// Once SetDatabaseManager has been called (the anti-entropy runtime path),
+// persistSchemaVersions must write through the live DatabaseManager instead -
+// opening the MetaStore by path a second time would deadlock against Pebble's
+// exclusive lock, since the DatabaseManager already holds it open.
+func TestCatchUpClient_PersistSchemaVersions_WithManagerUsesLiveStore(t *testing.T) {
+	dataDir := t.TempDir()
+	dbMgr, err := db.NewDatabaseManager(dataDir, 1, hlc.NewClock(1))
+	require.NoError(t, err)
+	defer dbMgr.Close()
+
+	registry := NewNodeRegistry(1, "localhost:5001")
+	client := NewCatchUpClient(1, dataDir, registry, nil)
+	client.SetDatabaseManager(dbMgr)
+
+	require.NoError(t, client.persistSchemaVersions(map[string]uint64{"appdb": 6}))
+
+	systemDB, err := dbMgr.GetDatabase(db.SystemDatabaseName)
+	require.NoError(t, err)
+	got, err := systemDB.GetMetaStore().GetSchemaVersion("appdb")
+	require.NoError(t, err)
+	require.Equal(t, int64(6), got)
+}
+
+// Pins the exact failure this fix removes: without SetDatabaseManager, the
+// runtime path would try to open the system MetaStore a second time while the
+// DatabaseManager already holds it open, and fail. This proves
+// persistSchemaVersions only avoids that failure because it dispatches to the
+// live-manager path once one is set.
+func TestCatchUpClient_PersistSchemaVersions_PathOpenFailsAgainstLiveManager(t *testing.T) {
+	dataDir := t.TempDir()
+	dbMgr, err := db.NewDatabaseManager(dataDir, 1, hlc.NewClock(1))
+	require.NoError(t, err)
+	defer dbMgr.Close()
+
+	registry := NewNodeRegistry(1, "localhost:5001")
+	client := NewCatchUpClient(1, dataDir, registry, nil)
+	// Deliberately do NOT call SetDatabaseManager, to force the path-based
+	// branch while dbMgr is already holding the MetaStore open.
+
+	err = client.persistSchemaVersions(map[string]uint64{"appdb": 6})
+	require.Error(t, err)
+}
+
+// SchemaVersionRestoreError must be detectable through fmt.Errorf's %w
+// wrapping, since applySnapshot's own wrapping and CatchUpFromPeer's
+// "failed to apply snapshot: %w" wrapping both sit between where the error is
+// created and where FilesSwappedDespiteError inspects it.
+func TestFilesSwappedDespiteError(t *testing.T) {
+	require.True(t, FilesSwappedDespiteError(nil), "no error at all means the snapshot succeeded")
+
+	schemaErr := &SchemaVersionRestoreError{err: errors.New("boom")}
+	wrapped := fmt.Errorf("failed to apply snapshot: %w", schemaErr)
+	require.True(t, FilesSwappedDespiteError(wrapped),
+		"a schema-version-restore error means files were already swapped")
+
+	require.False(t, FilesSwappedDespiteError(errors.New("connection refused")),
+		"an unrelated error must not be treated as files-swapped")
+}
+
+// trailerOnlyStreamSnapshotServer implements just enough of MarmotServiceServer
+// to prove schema versions set via stream.SetTrailer on the server side really
+// do arrive at stream.Trailer() on the client side over a real gRPC
+// connection - the mechanism SnapshotVersionsForRestore depends on.
+type trailerOnlyStreamSnapshotServer struct {
+	UnimplementedMarmotServiceServer
+	trailer metadata.MD
+}
+
+func (s *trailerOnlyStreamSnapshotServer) StreamSnapshot(req *SnapshotRequest, stream MarmotService_StreamSnapshotServer) error {
+	stream.SetTrailer(s.trailer)
+	return nil
+}
+
+func TestStreamSnapshotTrailer_PropagatesOverRealGRPCConnection(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	wantVersions := map[string]uint64{"appdb": 4, "otherdb": 1}
+	mockServer := &trailerOnlyStreamSnapshotServer{trailer: snapshotSchemaVersionsTrailer(wantVersions)}
+	grpcServer := grpc.NewServer()
+	RegisterMarmotServiceServer(grpcServer, mockServer)
+	go func() { _ = grpcServer.Serve(listener) }()
+	defer grpcServer.Stop()
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := NewMarmotServiceClient(conn)
+	stream, err := client.StreamSnapshot(context.Background(), &SnapshotRequest{RequestingNodeId: 1})
+	require.NoError(t, err)
+
+	// Drain the stream: trailer metadata is only populated once Recv() has
+	// observed the RPC's end (io.EOF here, since the mock sends no chunks).
+	_, err = stream.Recv()
+	require.ErrorIs(t, err, io.EOF)
+
+	got := SnapshotVersionsForRestore(nil, stream)
+	require.Equal(t, wantVersions, got)
 }

--- a/grpc/marmot.pb.go
+++ b/grpc/marmot.pb.go
@@ -1438,8 +1438,12 @@ type TransactionResponse struct {
 	// Write-write conflict detection
 	ConflictDetected bool   `protobuf:"varint,4,opt,name=conflict_detected,json=conflictDetected,proto3" json:"conflict_detected,omitempty"`
 	ConflictDetails  string `protobuf:"bytes,5,opt,name=conflict_details,json=conflictDetails,proto3" json:"conflict_details,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Rejected marks a deterministic refusal of the statement itself during
+	// PREPARE (for example DDL SQLite cannot apply), as opposed to a timeout
+	// or storage error. See db.PrepareResult.Rejected.
+	Rejected      bool `protobuf:"varint,6,opt,name=rejected,proto3" json:"rejected,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TransactionResponse) Reset() {
@@ -1505,6 +1509,13 @@ func (x *TransactionResponse) GetConflictDetails() string {
 		return x.ConflictDetails
 	}
 	return ""
+}
+
+func (x *TransactionResponse) GetRejected() bool {
+	if x != nil {
+		return x.Rejected
+	}
+	return false
 }
 
 type ReadRequest struct {
@@ -3434,14 +3445,15 @@ const file_grpc_marmot_proto_rawDesc = "" +
 	"\x03HLC\x12\x1b\n" +
 	"\twall_time\x18\x01 \x01(\x03R\bwallTime\x12\x18\n" +
 	"\alogical\x18\x02 \x01(\x05R\alogical\x12\x17\n" +
-	"\anode_id\x18\x03 \x01(\x04R\x06nodeId\"\xdb\x01\n" +
+	"\anode_id\x18\x03 \x01(\x04R\x06nodeId\"\xf7\x01\n" +
 	"\x13TransactionResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12-\n" +
 	"\n" +
 	"applied_at\x18\x03 \x01(\v2\x0e.marmot.v2.HLCR\tappliedAt\x12+\n" +
 	"\x11conflict_detected\x18\x04 \x01(\bR\x10conflictDetected\x12)\n" +
-	"\x10conflict_details\x18\x05 \x01(\tR\x0fconflictDetails\"\xf4\x01\n" +
+	"\x10conflict_details\x18\x05 \x01(\tR\x0fconflictDetails\x12\x1a\n" +
+	"\brejected\x18\x06 \x01(\bR\brejected\"\xf4\x01\n" +
 	"\vReadRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12$\n" +
 	"\x0esource_node_id\x18\x02 \x01(\x04R\fsourceNodeId\x12/\n" +

--- a/grpc/marmot.pb.go
+++ b/grpc/marmot.pb.go
@@ -2242,8 +2242,12 @@ type DatabaseSnapshotMetadata struct {
 	SnapshotTxnId  uint64                 `protobuf:"varint,2,opt,name=snapshot_txn_id,json=snapshotTxnId,proto3" json:"snapshot_txn_id,omitempty"` // Per-database CDC offset
 	SizeBytes      int64                  `protobuf:"varint,3,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
 	Sha256Checksum string                 `protobuf:"bytes,4,opt,name=sha256_checksum,json=sha256Checksum,proto3" json:"sha256_checksum,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Schema version the source node had for this database. Snapshots carry only
+	// SQLite files, so without this the receiver cannot recover the version and
+	// would refuse every transaction that requires a newer schema.
+	SchemaVersion uint64 `protobuf:"varint,5,opt,name=schema_version,json=schemaVersion,proto3" json:"schema_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DatabaseSnapshotMetadata) Reset() {
@@ -2302,6 +2306,13 @@ func (x *DatabaseSnapshotMetadata) GetSha256Checksum() string {
 		return x.Sha256Checksum
 	}
 	return ""
+}
+
+func (x *DatabaseSnapshotMetadata) GetSchemaVersion() uint64 {
+	if x != nil {
+		return x.SchemaVersion
+	}
+	return 0
 }
 
 type SnapshotRequest struct {
@@ -3492,13 +3503,14 @@ const file_grpc_marmot_proto_rawDesc = "" +
 	"\bfilename\x18\x02 \x01(\tR\bfilename\x12\x1d\n" +
 	"\n" +
 	"size_bytes\x18\x03 \x01(\x03R\tsizeBytes\x12'\n" +
-	"\x0fsha256_checksum\x18\x04 \x01(\tR\x0esha256Checksum\"\xaf\x01\n" +
+	"\x0fsha256_checksum\x18\x04 \x01(\tR\x0esha256Checksum\"\xd6\x01\n" +
 	"\x18DatabaseSnapshotMetadata\x12#\n" +
 	"\rdatabase_name\x18\x01 \x01(\tR\fdatabaseName\x12&\n" +
 	"\x0fsnapshot_txn_id\x18\x02 \x01(\x04R\rsnapshotTxnId\x12\x1d\n" +
 	"\n" +
 	"size_bytes\x18\x03 \x01(\x03R\tsizeBytes\x12'\n" +
-	"\x0fsha256_checksum\x18\x04 \x01(\tR\x0esha256Checksum\"[\n" +
+	"\x0fsha256_checksum\x18\x04 \x01(\tR\x0esha256Checksum\x12%\n" +
+	"\x0eschema_version\x18\x05 \x01(\x04R\rschemaVersion\"[\n" +
 	"\x0fSnapshotRequest\x12,\n" +
 	"\x12requesting_node_id\x18\x01 \x01(\x04R\x10requestingNodeId\x12\x1a\n" +
 	"\bdatabase\x18\x02 \x01(\tR\bdatabase\"\xc8\x01\n" +

--- a/grpc/marmot.proto
+++ b/grpc/marmot.proto
@@ -323,6 +323,10 @@ message DatabaseSnapshotMetadata {
   uint64 snapshot_txn_id = 2;      // Per-database CDC offset
   int64 size_bytes = 3;
   string sha256_checksum = 4;
+  // Schema version the source node had for this database. Snapshots carry only
+  // SQLite files, so without this the receiver cannot recover the version and
+  // would refuse every transaction that requires a newer schema.
+  uint64 schema_version = 5;
 }
 
 message SnapshotRequest {

--- a/grpc/marmot.proto
+++ b/grpc/marmot.proto
@@ -237,6 +237,10 @@ message TransactionResponse {
   // Write-write conflict detection
   bool conflict_detected = 4;
   string conflict_details = 5;
+  // Rejected marks a deterministic refusal of the statement itself during
+  // PREPARE (for example DDL SQLite cannot apply), as opposed to a timeout
+  // or storage error. See db.PrepareResult.Rejected.
+  bool rejected = 6;
 }
 
 message ReadRequest {

--- a/grpc/replication_handler.go
+++ b/grpc/replication_handler.go
@@ -157,6 +157,7 @@ func (rh *ReplicationHandler) handlePrepare(ctx context.Context, req *Transactio
 		ErrorMessage:     result.Error,
 		ConflictDetected: result.ConflictDetected,
 		ConflictDetails:  result.ConflictDetails,
+		Rejected:         result.Rejected,
 	}
 	if result.Success {
 		resp.AppliedAt = &HLC{

--- a/grpc/replicator_adapter.go
+++ b/grpc/replicator_adapter.go
@@ -64,6 +64,7 @@ func (gr *GRPCReplicator) ReplicateTransaction(ctx context.Context, nodeID uint6
 		Error:            grpcResp.ErrorMessage,
 		ConflictDetected: grpcResp.ConflictDetected,
 		ConflictDetails:  grpcResp.ConflictDetails,
+		Rejected:         grpcResp.Rejected,
 	}
 
 	return resp, nil

--- a/grpc/replicator_adapter_test.go
+++ b/grpc/replicator_adapter_test.go
@@ -1,0 +1,108 @@
+package grpc
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/maxpert/marmot/coordinator"
+	"github.com/maxpert/marmot/db"
+	"github.com/maxpert/marmot/hlc"
+	"github.com/maxpert/marmot/protocol"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// prepareOnlyServer exposes a real *ReplicationHandler over gRPC. It is
+// intentionally minimal - only ReplicateTransaction is wired - to keep this
+// test's server-side surface limited to what PREPARE actually needs, the
+// same pattern trailerOnlyStreamSnapshotServer uses in catch_up_test.go.
+type prepareOnlyServer struct {
+	UnimplementedMarmotServiceServer
+	handler *ReplicationHandler
+}
+
+func (s *prepareOnlyServer) ReplicateTransaction(ctx context.Context, req *TransactionRequest) (*TransactionResponse, error) {
+	return s.handler.HandleReplicateTransaction(ctx, req)
+}
+
+// TestGRPCReplicator_PrepareRejectionCarriesOverRealGRPCConnection is the
+// wire-level regression test for the PREPARE Rejected verdict: a real
+// ReplicationEngine.Prepare rejection (a duplicate-column DDL SQLite refuses)
+// must survive real protobuf marshaling to a real TCP gRPC connection and
+// come back out through GRPCReplicator.ReplicateTransaction as
+// coordinator.ReplicationResponse.Rejected == true. A struct literal with
+// Rejected set by hand proves nothing about the wire; this drives it through
+// grpc.NewServer/grpc.NewClient exactly as production traffic does.
+func TestGRPCReplicator_PrepareRejectionCarriesOverRealGRPCConnection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "marmot_test_prepare_rejection_wire")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	clock := hlc.NewClock(1)
+	dbMgr, err := db.NewDatabaseManager(tmpDir, 1, clock)
+	require.NoError(t, err)
+	defer dbMgr.Close()
+
+	const testDB = "test_prepare_rejection"
+	require.NoError(t, dbMgr.CreateDatabase(testDB))
+
+	dbInstance, err := dbMgr.GetDatabase(testDB)
+	require.NoError(t, err)
+	_, err = dbInstance.GetDB().Exec(`CREATE TABLE groups (group_id INTEGER PRIMARY KEY, creation_date datetime)`)
+	require.NoError(t, err)
+
+	systemDB, err := dbMgr.GetDatabase(db.SystemDatabaseName)
+	require.NoError(t, err)
+	handler := NewReplicationHandler(1, dbMgr, clock, db.NewSchemaVersionManager(systemDB.GetMetaStore()))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	grpcServer := grpc.NewServer()
+	RegisterMarmotServiceServer(grpcServer, &prepareOnlyServer{handler: handler})
+	go func() { _ = grpcServer.Serve(listener) }()
+	defer grpcServer.Stop()
+
+	const peerNodeID = 2
+	client := NewClient(peerNodeID)
+	require.NoError(t, client.Connect(peerNodeID, listener.Addr().String()))
+	defer client.Close()
+
+	replicator := NewGRPCReplicator(client)
+
+	req := &coordinator.ReplicationRequest{
+		TxnID:    500,
+		NodeID:   peerNodeID,
+		Database: testDB,
+		Phase:    coordinator.PhasePrep,
+		StartTS:  clock.Now(),
+		Statements: []protocol.Statement{
+			{
+				Type:     protocol.StatementDDL,
+				Database: testDB,
+				SQL:      `ALTER TABLE groups ADD COLUMN creation_date datetime NOT NULL DEFAULT '2026-08-10 19:38:56.952152'`,
+			},
+		},
+	}
+
+	resp, err := replicator.ReplicateTransaction(context.Background(), peerNodeID, req)
+	require.NoError(t, err)
+
+	if resp.Success {
+		t.Fatal("expected PREPARE to fail: ALTER TABLE ADD COLUMN duplicate column must be rejected")
+	}
+	if !resp.Rejected {
+		t.Fatalf("expected Rejected=true to survive the real gRPC round trip, got false (error: %q)", resp.Error)
+	}
+	require.Contains(t, resp.Error, "duplicate column name: creation_date")
+
+	// The connection carried a genuine sqlite3 error two hops (handler ->
+	// wire -> adapter); verify the client-facing MySQL mapping end to end too.
+	mysqlErr := protocol.ConvertToMySQLError(&coordinator.RemotePrepareRejectedError{NodeID: peerNodeID, Reason: resp.Error})
+	if mysqlErr.Code != protocol.ErrCodeDupFieldName {
+		t.Errorf("MySQL error code: got %d, want %d (ErrCodeDupFieldName)", mysqlErr.Code, protocol.ErrCodeDupFieldName)
+	}
+}

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -860,6 +860,11 @@ func (s *Server) GetSnapshotInfo(ctx context.Context, req *SnapshotInfoRequest) 
 		return nil, fmt.Errorf("failed to get snapshot info: %w", err)
 	}
 
+	// Schema versions travel with the snapshot: they live in the MetaStore, which
+	// is not part of the transferred files, and a receiver that cannot recover
+	// them refuses every transaction requiring a newer schema.
+	schemaVersions := snapshotSchemaVersions(dbManager)
+
 	// Calculate total size and chunks (estimates)
 	var totalSize int64
 	var dbInfos []*DatabaseFileInfo
@@ -886,6 +891,7 @@ func (s *Server) GetSnapshotInfo(ctx context.Context, req *SnapshotInfoRequest) 
 			SnapshotTxnId:  txnID,
 			SizeBytes:      snap.Size,
 			Sha256Checksum: snap.SHA256,
+			SchemaVersion:  schemaVersions[snap.Name],
 		})
 	}
 

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -930,6 +930,7 @@ func (s *Server) StreamSnapshot(req *SnapshotRequest, stream MarmotService_Strea
 
 	var snapshots []db.SnapshotInfo
 	var maxTxnID uint64
+	var schemaVersions map[string]uint64
 	var tempDir string
 	var shouldCleanup bool
 
@@ -954,6 +955,12 @@ func (s *Server) StreamSnapshot(req *SnapshotRequest, stream MarmotService_Strea
 			maxTxnID = cached.maxTxnID
 			tempDir = cached.tempDir
 			shouldCleanup = false
+
+			// Single-database snapshots don't capture schema versions in the
+			// same atomic step as the file copy (unlike TakeSnapshotToDir), so
+			// read the current value here instead - it is the best available
+			// estimate for this legacy path.
+			schemaVersions = snapshotSchemaVersions(dbManager)
 		} else {
 			// Cache miss or expired - create new snapshot
 			if exists {
@@ -985,6 +992,7 @@ func (s *Server) StreamSnapshot(req *SnapshotRequest, stream MarmotService_Strea
 			}
 			snapshots = []db.SnapshotInfo{snapshot}
 			maxTxnID = txnID
+			schemaVersions = snapshotSchemaVersions(dbManager)
 
 			// Cache the snapshot
 			ttl := time.Duration(cfg.Config.Replica.SnapshotCacheTTLSec) * time.Second
@@ -1016,7 +1024,7 @@ func (s *Server) StreamSnapshot(req *SnapshotRequest, stream MarmotService_Strea
 			return fmt.Errorf("failed to create temp directory: %w", err)
 		}
 
-		snapshots, maxTxnID, err = dbManager.TakeSnapshotToDir(tempDir)
+		snapshots, maxTxnID, schemaVersions, err = dbManager.TakeSnapshotToDir(tempDir)
 		if err != nil {
 			os.RemoveAll(tempDir)
 			return fmt.Errorf("failed to take snapshot: %w", err)
@@ -1028,6 +1036,15 @@ func (s *Server) StreamSnapshot(req *SnapshotRequest, stream MarmotService_Strea
 			Msg("Full snapshot created (no caching)")
 
 		shouldCleanup = true
+	}
+
+	// Advertise the schema versions captured with these exact files as stream
+	// trailer metadata. GetSnapshotInfo's earlier estimate can go stale if a
+	// DDL commits between that call and this one; receivers prefer this value
+	// (see grpc.SnapshotVersionsForRestore) so they never restore a version
+	// older than the files they actually received.
+	if trailer := snapshotSchemaVersionsTrailer(schemaVersions); trailer != nil {
+		stream.SetTrailer(trailer)
 	}
 
 	// Cleanup temp directory when done (only for non-cached snapshots)

--- a/grpc/snapshot_schema_version.go
+++ b/grpc/snapshot_schema_version.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 
 	"github.com/maxpert/marmot/db"
+	"github.com/maxpert/marmot/encoding"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/metadata"
 )
 
 // snapshotMetaStoreOptions sizes the short-lived MetaStore handle used to record
@@ -50,7 +52,7 @@ func snapshotSchemaVersions(dbManager *db.DatabaseManager) map[string]uint64 {
 }
 
 // persistSnapshotSchemaVersions records the schema versions carried by a snapshot
-// into the system database's MetaStore.
+// into the system database's MetaStore, opening it directly by path.
 //
 // A snapshot transfers SQLite files only, while schema versions live in the
 // MetaStore. A node that catches up without this keeps reporting version 0 and
@@ -59,10 +61,11 @@ func snapshotSchemaVersions(dbManager *db.DatabaseManager) map[string]uint64 {
 // because the only other way to advance the version is committing a DDL
 // transaction it can no longer take part in.
 //
-// Used by the join path, where the DatabaseManager does not exist yet and the
-// MetaStore has to be opened directly by path.
-func persistSnapshotSchemaVersions(dataDir string, metadata []*DatabaseSnapshotMetadata) error {
-	versions := SnapshotSchemaVersions(metadata)
+// Used by the join path, where the DatabaseManager does not exist yet. Opening
+// the MetaStore a second time by path while a DatabaseManager already holds it
+// open would fail: Pebble takes an exclusive lock per process. Runtime restores
+// (anti-entropy) must go through persistSnapshotSchemaVersionsViaManager instead.
+func persistSnapshotSchemaVersions(dataDir string, versions map[string]uint64) error {
 	if len(versions) == 0 {
 		return nil
 	}
@@ -77,15 +80,98 @@ func persistSnapshotSchemaVersions(dataDir string, metadata []*DatabaseSnapshotM
 	return db.RestoreSchemaVersions(metaStore, versions)
 }
 
+// persistSnapshotSchemaVersionsViaManager records the schema versions carried by
+// a snapshot into the system database's MetaStore, writing through an
+// already-open DatabaseManager instead of opening a second handle on the same
+// Pebble directory (which would deadlock against Pebble's per-process
+// exclusive lock). Used by the anti-entropy runtime path, where the
+// DatabaseManager already exists.
+func persistSnapshotSchemaVersionsViaManager(dbManager *db.DatabaseManager, versions map[string]uint64) error {
+	if len(versions) == 0 {
+		return nil
+	}
+
+	systemDB, err := dbManager.GetDatabase(db.SystemDatabaseName)
+	if err != nil {
+		return fmt.Errorf("system database unavailable: %w", err)
+	}
+
+	return db.RestoreSchemaVersions(systemDB.GetMetaStore(), versions)
+}
+
 // SnapshotSchemaVersions extracts the schema versions advertised with a snapshot,
 // keyed by database name.
-func SnapshotSchemaVersions(metadata []*DatabaseSnapshotMetadata) map[string]uint64 {
-	versions := make(map[string]uint64, len(metadata))
-	for _, meta := range metadata {
+func SnapshotSchemaVersions(snapshotMetadata []*DatabaseSnapshotMetadata) map[string]uint64 {
+	versions := make(map[string]uint64, len(snapshotMetadata))
+	for _, meta := range snapshotMetadata {
 		if meta == nil || meta.DatabaseName == "" || meta.SchemaVersion == 0 {
 			continue
 		}
 		versions[meta.DatabaseName] = meta.SchemaVersion
 	}
 	return versions
+}
+
+// snapshotSchemaVersionsTrailerKey carries schema versions as gRPC trailer
+// metadata on the StreamSnapshot RPC. Binary values need the "-bin" key suffix;
+// grpc-go base64-encodes/decodes them on the wire automatically.
+const snapshotSchemaVersionsTrailerKey = "marmot-snapshot-schema-versions-bin"
+
+// snapshotSchemaVersionsTrailer builds gRPC trailer metadata carrying schema
+// versions captured atomically with the snapshot files actually streamed, so
+// the receiver does not have to trust the separate (and potentially stale)
+// read taken earlier by GetSnapshotInfo. Returns nil when there is nothing to
+// carry, so callers see no trailer rather than an empty one.
+func snapshotSchemaVersionsTrailer(versions map[string]uint64) metadata.MD {
+	if len(versions) == 0 {
+		return nil
+	}
+
+	payload, err := encoding.Marshal(versions)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to encode schema versions for snapshot trailer")
+		return nil
+	}
+
+	return metadata.Pairs(snapshotSchemaVersionsTrailerKey, string(payload))
+}
+
+// decodeSchemaVersionsTrailer decodes schema versions carried in a snapshot
+// stream's trailer. Returns (nil, nil) when no trailer was set - by an older
+// server, or a stream with nothing to restore - so callers can fall back to
+// the versions advertised earlier by GetSnapshotInfo without treating it as an
+// error.
+func decodeSchemaVersionsTrailer(md metadata.MD) (map[string]uint64, error) {
+	values := md.Get(snapshotSchemaVersionsTrailerKey)
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	var versions map[string]uint64
+	if err := encoding.Unmarshal([]byte(values[0]), &versions); err != nil {
+		return nil, fmt.Errorf("failed to decode schema versions trailer: %w", err)
+	}
+	return versions, nil
+}
+
+// SnapshotStreamTrailer is satisfied by both ends of the StreamSnapshot gRPC
+// stream. It is used to read the authoritative schema versions the server
+// attaches as trailer metadata once the snapshot's files have been produced.
+type SnapshotStreamTrailer interface {
+	Trailer() metadata.MD
+}
+
+// SnapshotVersionsForRestore chooses which schema versions to restore after a
+// snapshot. It prefers the versions carried in the stream's trailer - captured
+// atomically with the files that were actually streamed - and falls back to
+// the versions advertised earlier by GetSnapshotInfo, which can go stale if a
+// DDL commits between that call and the StreamSnapshot call that follows it.
+func SnapshotVersionsForRestore(snapshotMetadata []*DatabaseSnapshotMetadata, stream SnapshotStreamTrailer) map[string]uint64 {
+	trailerVersions, err := decodeSchemaVersionsTrailer(stream.Trailer())
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to decode schema versions from snapshot trailer, falling back to GetSnapshotInfo metadata")
+	} else if len(trailerVersions) > 0 {
+		return trailerVersions
+	}
+	return SnapshotSchemaVersions(snapshotMetadata)
 }

--- a/grpc/snapshot_schema_version.go
+++ b/grpc/snapshot_schema_version.go
@@ -1,0 +1,91 @@
+package grpc
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/maxpert/marmot/db"
+	"github.com/rs/zerolog/log"
+)
+
+// snapshotMetaStoreOptions sizes the short-lived MetaStore handle used to record
+// restored schema versions. The store is opened, written and closed immediately,
+// so it only needs minimal memory. MemTableCount is 2 because Pebble rejects a
+// stop-writes threshold below that when creating a store, and a joining node has
+// no system MetaStore yet.
+func snapshotMetaStoreOptions() db.PebbleMetaStoreOptions {
+	return db.PebbleMetaStoreOptions{
+		CacheSizeMB:           16,
+		MemTableSizeMB:        16,
+		MemTableCount:         2,
+		L0CompactionThreshold: 4,
+		L0StopWrites:          12,
+	}
+}
+
+// snapshotSchemaVersions reads this node's schema version for every database so
+// they can be advertised alongside a snapshot. Returns an empty map when the
+// versions cannot be read - the snapshot itself is still usable, the receiver
+// simply has nothing to restore.
+func snapshotSchemaVersions(dbManager *db.DatabaseManager) map[string]uint64 {
+	systemDB, err := dbManager.GetDatabase(db.SystemDatabaseName)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to reach system database for snapshot schema versions")
+		return nil
+	}
+
+	stored, err := systemDB.GetMetaStore().GetAllSchemaVersions()
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to read schema versions for snapshot")
+		return nil
+	}
+
+	versions := make(map[string]uint64, len(stored))
+	for database, version := range stored {
+		if version > 0 {
+			versions[database] = uint64(version)
+		}
+	}
+	return versions
+}
+
+// persistSnapshotSchemaVersions records the schema versions carried by a snapshot
+// into the system database's MetaStore.
+//
+// A snapshot transfers SQLite files only, while schema versions live in the
+// MetaStore. A node that catches up without this keeps reporting version 0 and
+// then refuses every transaction stamped with a higher RequiredSchemaVersion -
+// including plain DML - so it silently stops replicating and never recovers,
+// because the only other way to advance the version is committing a DDL
+// transaction it can no longer take part in.
+//
+// Used by the join path, where the DatabaseManager does not exist yet and the
+// MetaStore has to be opened directly by path.
+func persistSnapshotSchemaVersions(dataDir string, metadata []*DatabaseSnapshotMetadata) error {
+	versions := SnapshotSchemaVersions(metadata)
+	if len(versions) == 0 {
+		return nil
+	}
+
+	metaPath := filepath.Join(dataDir, db.SystemDatabaseName+"_meta.pebble")
+	metaStore, err := db.NewPebbleMetaStore(metaPath, snapshotMetaStoreOptions())
+	if err != nil {
+		return fmt.Errorf("failed to open system MetaStore to restore schema versions: %w", err)
+	}
+	defer metaStore.Close()
+
+	return db.RestoreSchemaVersions(metaStore, versions)
+}
+
+// SnapshotSchemaVersions extracts the schema versions advertised with a snapshot,
+// keyed by database name.
+func SnapshotSchemaVersions(metadata []*DatabaseSnapshotMetadata) map[string]uint64 {
+	versions := make(map[string]uint64, len(metadata))
+	for _, meta := range metadata {
+		if meta == nil || meta.DatabaseName == "" || meta.SchemaVersion == 0 {
+			continue
+		}
+		versions[meta.DatabaseName] = meta.SchemaVersion
+	}
+	return versions
+}

--- a/grpc/snapshot_schema_version_test.go
+++ b/grpc/snapshot_schema_version_test.go
@@ -1,0 +1,67 @@
+package grpc
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/maxpert/marmot/db"
+	"github.com/stretchr/testify/require"
+)
+
+// A node that catches up by snapshot receives only SQLite files; schema versions
+// live in the system database's MetaStore and are not part of that transfer.
+// Without restoring them the node reports version 0 forever and every later
+// transaction carrying a RequiredSchemaVersion is refused, which silently drops
+// the node out of replication.
+func TestPersistSnapshotSchemaVersions(t *testing.T) {
+	dataDir := t.TempDir()
+
+	metadata := []*DatabaseSnapshotMetadata{
+		{DatabaseName: "appdb", SchemaVersion: 17},
+		{DatabaseName: "otherdb", SchemaVersion: 3},
+	}
+
+	require.NoError(t, persistSnapshotSchemaVersions(dataDir, metadata))
+
+	versions := readSchemaVersions(t, dataDir)
+	require.Equal(t, int64(17), versions["appdb"])
+	require.Equal(t, int64(3), versions["otherdb"])
+}
+
+// Restoring an older snapshot must not roll a node's schema version backwards:
+// the node may have applied DDL after the snapshot was taken.
+func TestPersistSnapshotSchemaVersionsNeverGoesBackwards(t *testing.T) {
+	dataDir := t.TempDir()
+
+	require.NoError(t, persistSnapshotSchemaVersions(dataDir,
+		[]*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 17}}))
+	require.NoError(t, persistSnapshotSchemaVersions(dataDir,
+		[]*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 5}}))
+
+	require.Equal(t, int64(17), readSchemaVersions(t, dataDir)["appdb"])
+}
+
+func TestPersistSnapshotSchemaVersionsIgnoresEmptyMetadata(t *testing.T) {
+	dataDir := t.TempDir()
+
+	require.NoError(t, persistSnapshotSchemaVersions(dataDir, nil))
+	require.NoError(t, persistSnapshotSchemaVersions(dataDir, []*DatabaseSnapshotMetadata{
+		{DatabaseName: "", SchemaVersion: 4},      // no database name
+		{DatabaseName: "appdb", SchemaVersion: 0}, // nothing to restore
+	}))
+
+	require.Empty(t, readSchemaVersions(t, dataDir))
+}
+
+func readSchemaVersions(t *testing.T, dataDir string) map[string]int64 {
+	t.Helper()
+
+	metaPath := filepath.Join(dataDir, db.SystemDatabaseName+"_meta.pebble")
+	metaStore, err := db.NewPebbleMetaStore(metaPath, snapshotMetaStoreOptions())
+	require.NoError(t, err)
+	defer metaStore.Close()
+
+	versions, err := metaStore.GetAllSchemaVersions()
+	require.NoError(t, err)
+	return versions
+}

--- a/grpc/snapshot_schema_version_test.go
+++ b/grpc/snapshot_schema_version_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/maxpert/marmot/db"
+	"github.com/maxpert/marmot/hlc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 )
 
 // A node that catches up by snapshot receives only SQLite files; schema versions
@@ -21,7 +23,7 @@ func TestPersistSnapshotSchemaVersions(t *testing.T) {
 		{DatabaseName: "otherdb", SchemaVersion: 3},
 	}
 
-	require.NoError(t, persistSnapshotSchemaVersions(dataDir, metadata))
+	require.NoError(t, persistSnapshotSchemaVersions(dataDir, SnapshotSchemaVersions(metadata)))
 
 	versions := readSchemaVersions(t, dataDir)
 	require.Equal(t, int64(17), versions["appdb"])
@@ -34,9 +36,9 @@ func TestPersistSnapshotSchemaVersionsNeverGoesBackwards(t *testing.T) {
 	dataDir := t.TempDir()
 
 	require.NoError(t, persistSnapshotSchemaVersions(dataDir,
-		[]*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 17}}))
+		SnapshotSchemaVersions([]*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 17}})))
 	require.NoError(t, persistSnapshotSchemaVersions(dataDir,
-		[]*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 5}}))
+		SnapshotSchemaVersions([]*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 5}})))
 
 	require.Equal(t, int64(17), readSchemaVersions(t, dataDir)["appdb"])
 }
@@ -44,13 +46,62 @@ func TestPersistSnapshotSchemaVersionsNeverGoesBackwards(t *testing.T) {
 func TestPersistSnapshotSchemaVersionsIgnoresEmptyMetadata(t *testing.T) {
 	dataDir := t.TempDir()
 
-	require.NoError(t, persistSnapshotSchemaVersions(dataDir, nil))
-	require.NoError(t, persistSnapshotSchemaVersions(dataDir, []*DatabaseSnapshotMetadata{
+	require.NoError(t, persistSnapshotSchemaVersions(dataDir, SnapshotSchemaVersions(nil)))
+	require.NoError(t, persistSnapshotSchemaVersions(dataDir, SnapshotSchemaVersions([]*DatabaseSnapshotMetadata{
 		{DatabaseName: "", SchemaVersion: 4},      // no database name
 		{DatabaseName: "appdb", SchemaVersion: 0}, // nothing to restore
-	}))
+	})))
 
 	require.Empty(t, readSchemaVersions(t, dataDir))
+}
+
+// persistSnapshotSchemaVersions opens the system MetaStore by path. That is
+// only safe on the startup join path, where no DatabaseManager exists yet. If
+// a DatabaseManager is already running against the same dataDir - the runtime
+// anti-entropy case - Pebble's per-process exclusive lock makes a second open
+// of the same directory fail. This pins that failure mode so a future change
+// cannot silently reintroduce the anti-entropy stall this fix removes.
+func TestPersistSnapshotSchemaVersions_FailsWhenManagerAlreadyOpen(t *testing.T) {
+	dataDir := t.TempDir()
+
+	dbMgr, err := db.NewDatabaseManager(dataDir, 1, hlc.NewClock(1))
+	require.NoError(t, err)
+	defer dbMgr.Close()
+
+	err = persistSnapshotSchemaVersions(dataDir, SnapshotSchemaVersions(
+		[]*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 1}}))
+	require.Error(t, err)
+}
+
+// persistSnapshotSchemaVersionsViaManager is what the runtime path must use
+// instead: it writes through the DatabaseManager's already-open system
+// MetaStore, so it succeeds even while that same store is held open by the
+// DatabaseManager - the exact situation that fails above.
+func TestPersistSnapshotSchemaVersionsViaManager(t *testing.T) {
+	dataDir := t.TempDir()
+
+	dbMgr, err := db.NewDatabaseManager(dataDir, 1, hlc.NewClock(1))
+	require.NoError(t, err)
+	defer dbMgr.Close()
+
+	versions := map[string]uint64{"appdb": 9}
+	require.NoError(t, persistSnapshotSchemaVersionsViaManager(dbMgr, versions))
+
+	systemDB, err := dbMgr.GetDatabase(db.SystemDatabaseName)
+	require.NoError(t, err)
+	got, err := systemDB.GetMetaStore().GetSchemaVersion("appdb")
+	require.NoError(t, err)
+	require.Equal(t, int64(9), got)
+}
+
+func TestPersistSnapshotSchemaVersionsViaManager_IgnoresEmptyVersions(t *testing.T) {
+	dataDir := t.TempDir()
+
+	dbMgr, err := db.NewDatabaseManager(dataDir, 1, hlc.NewClock(1))
+	require.NoError(t, err)
+	defer dbMgr.Close()
+
+	require.NoError(t, persistSnapshotSchemaVersionsViaManager(dbMgr, nil))
 }
 
 func readSchemaVersions(t *testing.T, dataDir string) map[string]int64 {
@@ -64,4 +115,79 @@ func readSchemaVersions(t *testing.T, dataDir string) map[string]int64 {
 	versions, err := metaStore.GetAllSchemaVersions()
 	require.NoError(t, err)
 	return versions
+}
+
+// --- trailer encode/decode ---
+
+func TestSnapshotSchemaVersionsTrailer_RoundTrip(t *testing.T) {
+	versions := map[string]uint64{"appdb": 4, "otherdb": 1}
+
+	trailer := snapshotSchemaVersionsTrailer(versions)
+	require.NotNil(t, trailer)
+
+	got, err := decodeSchemaVersionsTrailer(trailer)
+	require.NoError(t, err)
+	require.Equal(t, versions, got)
+}
+
+func TestSnapshotSchemaVersionsTrailer_EmptyVersionsProduceNoTrailer(t *testing.T) {
+	require.Nil(t, snapshotSchemaVersionsTrailer(nil))
+	require.Nil(t, snapshotSchemaVersionsTrailer(map[string]uint64{}))
+}
+
+// An absent trailer (older server, or nothing to restore) must decode to a
+// nil map with no error, so callers fall back to GetSnapshotInfo metadata
+// instead of treating "no trailer" as a decode failure.
+func TestDecodeSchemaVersionsTrailer_AbsentIsNotAnError(t *testing.T) {
+	versions, err := decodeSchemaVersionsTrailer(metadata.MD{})
+	require.NoError(t, err)
+	require.Nil(t, versions)
+}
+
+func TestDecodeSchemaVersionsTrailer_CorruptPayloadErrors(t *testing.T) {
+	md := metadata.Pairs(snapshotSchemaVersionsTrailerKey, "not valid msgpack")
+	_, err := decodeSchemaVersionsTrailer(md)
+	require.Error(t, err)
+}
+
+// --- SnapshotVersionsForRestore ---
+
+type fakeSnapshotStreamTrailer struct {
+	trailer metadata.MD
+}
+
+func (f *fakeSnapshotStreamTrailer) Trailer() metadata.MD { return f.trailer }
+
+// The trailer - captured atomically with the files actually streamed - must
+// win over GetSnapshotInfo's earlier, separately-read metadata whenever both
+// are present. This is the fix for the race where a DDL commits between the
+// GetSnapshotInfo and StreamSnapshot RPCs.
+func TestSnapshotVersionsForRestore_PrefersTrailerOverMetadata(t *testing.T) {
+	staleMetadata := []*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 3}}
+	stream := &fakeSnapshotStreamTrailer{trailer: snapshotSchemaVersionsTrailer(map[string]uint64{"appdb": 4})}
+
+	got := SnapshotVersionsForRestore(staleMetadata, stream)
+	require.Equal(t, map[string]uint64{"appdb": 4}, got)
+}
+
+// An older server never sets the trailer. Receivers must fall back to
+// GetSnapshotInfo's metadata rather than restoring nothing.
+func TestSnapshotVersionsForRestore_FallsBackWhenNoTrailer(t *testing.T) {
+	fallbackMetadata := []*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 3}}
+	stream := &fakeSnapshotStreamTrailer{trailer: metadata.MD{}}
+
+	got := SnapshotVersionsForRestore(fallbackMetadata, stream)
+	require.Equal(t, map[string]uint64{"appdb": 3}, got)
+}
+
+// A corrupt trailer must not be trusted, but must also not make restore fail
+// outright - fall back to the metadata instead.
+func TestSnapshotVersionsForRestore_FallsBackOnCorruptTrailer(t *testing.T) {
+	fallbackMetadata := []*DatabaseSnapshotMetadata{{DatabaseName: "appdb", SchemaVersion: 3}}
+	stream := &fakeSnapshotStreamTrailer{
+		trailer: metadata.Pairs(snapshotSchemaVersionsTrailerKey, "not valid msgpack"),
+	}
+
+	got := SnapshotVersionsForRestore(fallbackMetadata, stream)
+	require.Equal(t, map[string]uint64{"appdb": 3}, got)
 }

--- a/marmot.go
+++ b/marmot.go
@@ -245,6 +245,13 @@ func main() {
 		return
 	}
 
+	// Wire the live DatabaseManager into the catch-up client so that runtime
+	// snapshot restores (anti-entropy, below) write schema versions through the
+	// already-open system MetaStore instead of opening a second handle on the
+	// same Pebble directory, which would deadlock against Pebble's exclusive
+	// lock. Must happen before anti-entropy starts invoking CatchUpFromPeer.
+	catchUpClient.SetDatabaseManager(dbMgr)
+
 	// Initialize CDC notification hub for signal-based change streaming
 	cdcHub := notify.NewHub()
 	dbMgr.SetCDCHub(cdcHub)
@@ -368,8 +375,15 @@ func main() {
 	// Create snapshot function for anti-entropy
 	snapshotFunc := func(ctx context.Context, peerNodeID uint64, peerAddr string, database string) error {
 		// Download snapshot to disk
-		if err := catchUpClient.CatchUpFromPeer(ctx, peerNodeID, peerAddr, database); err != nil {
-			return err
+		catchUpErr := catchUpClient.CatchUpFromPeer(ctx, peerNodeID, peerAddr, database)
+
+		// The download can fail after the snapshot's files were already swapped
+		// onto disk (e.g. restoring schema versions failed post-swap). Reopen
+		// unconditionally whenever that happened, or the node keeps serving the
+		// old connection against freshly-swapped files - even though the
+		// overall catch-up is reported as failed and gets retried.
+		if !marmotgrpc.FilesSwappedDespiteError(catchUpErr) {
+			return catchUpErr
 		}
 
 		// Reload the database connection to pick up the new snapshot file
@@ -380,7 +394,7 @@ func main() {
 		}
 
 		log.Info().Str("database", database).Msg("Database reloaded after snapshot download")
-		return nil
+		return catchUpErr
 	}
 
 	antiEntropy := marmotgrpc.NewAntiEntropyServiceFromConfig(

--- a/protocol/error_mapper.go
+++ b/protocol/error_mapper.go
@@ -67,6 +67,10 @@ func mapByMessage(msg string) *MySQLError {
 	switch {
 	case strings.Contains(lower, "no such table"):
 		return NewMySQLError(ErrCodeNoSuchTable, SQLStateNoSuchTable, msg)
+	// SQLite reports "duplicate column name: <col>" for ALTER TABLE ADD COLUMN on
+	// an existing column; clients expect MySQL's ER_DUP_FIELDNAME.
+	case strings.Contains(lower, "duplicate column name"):
+		return NewMySQLError(ErrCodeDupFieldName, SQLStateDupColumn, msg)
 	case strings.Contains(lower, "already exists"):
 		return NewMySQLError(ErrCodeTableExists, SQLStateTableExists, msg)
 	case strings.Contains(lower, "no column named"), strings.Contains(lower, "no such column"):

--- a/protocol/error_mapper_test.go
+++ b/protocol/error_mapper_test.go
@@ -144,6 +144,18 @@ func TestConvertToMySQLError_MessageBased(t *testing.T) {
 			wantSQLState: SQLStateTableExists,
 		},
 		{
+			name:         "duplicate column name",
+			errMsg:       "duplicate column name: creation_date",
+			wantCode:     ErrCodeDupFieldName,
+			wantSQLState: SQLStateDupColumn,
+		},
+		{
+			name:         "duplicate column name wrapped by prepare failure",
+			errMsg:       "local prepare failed: duplicate column name: creation_date",
+			wantCode:     ErrCodeDupFieldName,
+			wantSQLState: SQLStateDupColumn,
+		},
+		{
 			name:         "no column named",
 			errMsg:       "no column named foo",
 			wantCode:     ErrCodeBadField,

--- a/protocol/mysql_errors.go
+++ b/protocol/mysql_errors.go
@@ -8,6 +8,7 @@ const (
 	ErrCodeBadNull         uint16 = 1048
 	ErrCodeTableExists     uint16 = 1050
 	ErrCodeBadField        uint16 = 1054
+	ErrCodeDupFieldName    uint16 = 1060
 	ErrCodeDupEntry        uint16 = 1062
 	ErrCodeParseError      uint16 = 1064
 	ErrCodeTooBigRowsize   uint16 = 1118
@@ -29,6 +30,7 @@ const (
 	SQLStateTableExists = "42S01"
 	SQLStateNoSuchTable = "42S02"
 	SQLStateNoSuchCol   = "42S22"
+	SQLStateDupColumn   = "42S21"
 )
 
 // MySQLError represents a MySQL protocol error with error code and SQLSTATE

--- a/replica/stream_client.go
+++ b/replica/stream_client.go
@@ -773,11 +773,34 @@ func (s *StreamClient) applySnapshot(ctx context.Context, snapshotInfo *marmotgr
 		return fmt.Errorf("snapshot restore failed: %w", err)
 	}
 
+	// Restore the schema versions the snapshot was taken at, otherwise this node
+	// reports version 0 and refuses every transaction requiring a newer schema.
+	if err := s.restoreSchemaVersions(snapshotInfo.DatabaseMetadata); err != nil {
+		return fmt.Errorf("failed to restore schema versions from snapshot: %w", err)
+	}
+
 	log.Info().
 		Uint64("snapshot_txn_id", snapshotInfo.SnapshotTxnId).
 		Msg("Snapshot applied successfully via unified restorer")
 
 	return nil
+}
+
+// restoreSchemaVersions records snapshot schema versions through the live system
+// MetaStore. The replica keeps its own system database, so the versions are
+// written to the already-open store rather than by reopening it on disk.
+func (s *StreamClient) restoreSchemaVersions(metadata []*marmotgrpc.DatabaseSnapshotMetadata) error {
+	versions := marmotgrpc.SnapshotSchemaVersions(metadata)
+	if len(versions) == 0 {
+		return nil
+	}
+
+	systemDB, err := s.dbManager.GetDatabase(db.SystemDatabaseName)
+	if err != nil {
+		return fmt.Errorf("system database unavailable: %w", err)
+	}
+
+	return db.RestoreSchemaVersions(systemDB.GetMetaStore(), versions)
 }
 
 // replicaSnapshotStreamAdapter adapts MarmotService_StreamSnapshotClient to snapshot.ChunkReceiver

--- a/replica/stream_client.go
+++ b/replica/stream_client.go
@@ -775,7 +775,11 @@ func (s *StreamClient) applySnapshot(ctx context.Context, snapshotInfo *marmotgr
 
 	// Restore the schema versions the snapshot was taken at, otherwise this node
 	// reports version 0 and refuses every transaction requiring a newer schema.
-	if err := s.restoreSchemaVersions(snapshotInfo.DatabaseMetadata); err != nil {
+	// Prefer the versions captured atomically with these exact files (the
+	// stream trailer) over the earlier, potentially stale read from
+	// GetSnapshotInfo.
+	versions := marmotgrpc.SnapshotVersionsForRestore(snapshotInfo.DatabaseMetadata, stream)
+	if err := s.restoreSchemaVersions(versions); err != nil {
 		return fmt.Errorf("failed to restore schema versions from snapshot: %w", err)
 	}
 
@@ -789,8 +793,7 @@ func (s *StreamClient) applySnapshot(ctx context.Context, snapshotInfo *marmotgr
 // restoreSchemaVersions records snapshot schema versions through the live system
 // MetaStore. The replica keeps its own system database, so the versions are
 // written to the already-open store rather than by reopening it on disk.
-func (s *StreamClient) restoreSchemaVersions(metadata []*marmotgrpc.DatabaseSnapshotMetadata) error {
-	versions := marmotgrpc.SnapshotSchemaVersions(metadata)
+func (s *StreamClient) restoreSchemaVersions(versions map[string]uint64) error {
 	if len(versions) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Problem

Reported against the MySQL API while bringing up [lldap](https://github.com/lldap/lldap): its migration runs

```sql
ALTER TABLE groups ADD COLUMN creation_date datetime NOT NULL DEFAULT '...'
```

on a table that already has that column. MySQL answers `1060 Duplicate column name`, which lldap tolerates and moves past. Marmot instead returned:

```
ERROR 1105 (HY000): partial commit: local commit failed after remote quorum (bug in PREPARE): <nil>
```

and lldap died on startup.

The log line was accurate about there being a bug. PREPARE only wrote a durable write intent for DDL — the statement first executed at COMMIT. Nothing ever checked the DDL could actually be applied, so a doomed statement ACKed PREPARE on every node, the remote nodes committed first, and the coordinator's own commit then failed. The reported error also dropped its own cause: `localErr` was nil because the reason lived in the response, printing `<nil>`.

## The invariant this PR establishes

**PREPARE is the 2PC promise point: a participant that ACKs it must be able to COMMIT.**

Most of this PR is that one sentence, enforced everywhere it can be violated. Several of the commits below exist because a first attempt established it in one place and left a hole in another.

## What changed

### 1. Validate DDL during PREPARE (`e2b535b`)

DDL is validated at PREPARE by executing the statements inside a transaction that is always rolled back.

Executing-and-rolling-back is used rather than compiling only, because SQLite reports most DDL failures (duplicate column, invalid default, NOT NULL without default) only at execution time. Statements run in request order, so DDL that depends on schema created earlier in the same transaction still passes.

The coordinator surfaces the rejecting participant's own reason instead of a generic "coordinator must participate", and SQLite's duplicate-column error maps to MySQL `1060`/`42S21`.

### 2. Restore schema versions on snapshot catch-up (`f9a389f`)

Snapshots transfer SQLite files only, but schema versions live in the system database's MetaStore, which is not part of that transfer. A node that caught up by snapshot came back reporting version 0 while the cluster was ahead, and the schema gate in the replication handler then refused **all** of that node's PREPARE requests — plain DML included. The node stayed ALIVE in gossip while silently accepting nothing, and never recovered.

Snapshot metadata now carries the source node's schema version per database. Versions are never moved backwards, since the receiver may have applied DDL after the snapshot was taken.

### 3. Five defects found reviewing the above (`40f0b0b`)

Each was found during review of commits 1 and 2, confirmed against the code, and is covered by a test with a recorded mutation proof.

**Anti-entropy snapshot repair was broken (CRITICAL).** `persistSnapshotSchemaVersions` opened the system MetaStore by path. That is only valid on the startup join path — `applySnapshot` is also reached from `CatchUpFromPeer`, wired as the anti-entropy `snapshotFunc`, which runs after `NewDatabaseManager` already holds that Pebble directory open. The second open fails with `lock held by current process`, and it failed *after* the snapshot files were swapped, so `snapshotFunc` returned early and `ReopenDatabase` never ran — leaving the node serving old connections against new files. `CatchUpClient` now writes through the live MetaStore when one exists and opens by path only during join; `FilesSwappedDespiteError` lets the caller reopen unconditionally once files have been swapped.

**Remote PREPARE rejections were discarded at the wire (CRITICAL).** Every participant computed `PrepareResult.Rejected`, but `TransactionResponse` had no field for it, so a remote node's deterministic refusal arrived as `Rejected=false`, indistinguishable from a timeout. A node with schema drift produced a **retryable** `QuorumNotAchievedError` for a transaction that could never succeed — the client retried forever and the real reason never surfaced. Adds `TransactionResponse.rejected` (field 6), wired end to end. Quorum rules are unchanged and no single node gains veto power: a remote rejection only replaces the retry signal once quorum has separately failed.

**Transient SQLite errors were treated as final rejections (HIGH).** Rejection was decided by "not a context error", so a DDL that merely lost a lock race against concurrent DML was reported as a permanent refusal. `isDDLRejection` now classifies by typed `sqlite3` result code — `BUSY`, `LOCKED`, `NOMEM`, `IOERR`, `FULL`, `CANTOPEN`, `PROTOCOL`, `READONLY` are node-local conditions, not verdicts on the statement.

**Expensive DDL could not complete inside the prepare deadline (HIGH).** Validation executes the real statement but ran under `write_timeout_ms` (5s), while COMMIT's execution was unbounded — so a `CREATE INDEX` on a large table died at PREPARE and could never be applied. Adds `ddl_validation_timeout_ms` (default 60s), applied at every outer bound: the three `WriteTransaction` call sites, and `executePreparePhase`'s dispatch context and collector.

The same budget now bounds COMMIT. Without that, PREPARE would admit DDL taking up to 60s while each remote COMMIT RPC was still abandoned at 5s — a node could ACK PREPARE and then be structurally unable to COMMIT, which is the exact invariant this PR exists to establish. Both commit bounds were DDL-unaware: the per-node RPC context and `waitForRemoteQuorum`'s own collector.

**Snapshot schema versions were read outside the atomic point (MEDIUM).** `GetSnapshotInfo` read schema versions in a separate RPC from the `StreamSnapshot` call that produces the bytes, so a DDL committing between the two advertised a version the files did not match — and unlike file drift, that is invisible to the SHA256 check. `TakeSnapshotToDir` now returns versions captured in the same locked section as the file copy, carried as gRPC trailer metadata. The existing proto field remains as the fallback for older peers.

Also fixes `TxnBuilder.WithDDLStatement`, which never set `Type` — so tests that claimed to exercise the DDL path did not.

## Verification

Client behaviour, through a real MySQL driver using the prepared-statement path lldap uses:

| | before | after |
|---|---|---|
| duplicate column | `1105 partial commit ... : <nil>` | `1060 (42S21) duplicate column name: creation_date` |
| missing table | `1105 partial commit ... : <nil>` | `1146 (42S02) no such table: nosuchtable` |

On a live three node cluster: duplicate-column DDL is rejected at PREPARE with no `CRITICAL` partial-commit log on any node; valid DDL still replicates; 200 concurrent inserts against 10 concurrent ALTERs deadlock-free; a node killed during DDL catches up on restart; a node wiped and rejoined by snapshot logs `previous_version: 0 -> restored_version: 3` and converges. The same scenario on `master` leaves it stuck one column behind.

Automated, measured on the final tree with the source digest verified unchanged across every run:

| check | result |
|---|---|
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 1 — only two pre-existing findings, both outside this diff |
| full suite `./...` | exit 0, run twice |
| `-race` on `coordinator`, `grpc`, `protocol`, `replica`, `cfg` | exit 0, no races |
| `-race` on `db` | **exit 1** — see below |

**Correction to an earlier version of this description**, which claimed `-race` was clean on the touched packages: it is not. The `db` package fails under `-race` with data races in `MemoryMetaStore` / `XsyncTransactionStore`. They are present identically on pristine `master`, they are not introduced here, and no race frame touches a file this PR modifies — but the original claim was wrong and anyone relying on it would have been misled.

Tests added across both areas cover the validator, engine-level PREPARE rejection, rejection-vs-timeout classification, deadline-bounded dispatch for both phases, the remote rejection travelling over a real gRPC connection, the `1060` mapping, snapshot trailer round-trip, and schema version restore including the never-go-backwards rule.

## Notes for review

- Validation executes DDL for real before rolling back, so `CREATE INDEX` on a large table builds twice per node, and holds that node's single write connection for the duration. This is a deliberate trade-off: a compile-only fast path cannot prove an expensive DDL will succeed, and it misses the step-time errors that cause exactly this failure mode. Operators running DDL that exceeds `ddl_validation_timeout_ms` should raise it on every node.
- `grpc/marmot.pb.go` is regenerated from two added proto fields with matching generator versions; the diff is limited to those fields and their descriptors.

## Pre-existing issues found while verifying (not addressed here)

Each confirmed against a pristine `master` build. Worth their own issues:

1. **`cache=shared` has never been enabled.** `db_integration.go` builds its DSN as `dbPath + "?..."` without a `file:` prefix, and the driver truncates the DSN at `?` unless it starts with `file:` (`go-sqlite3/sqlite3.go:1449`). The `_`-prefixed params survive because the driver parses those in Go; only the URI-level `cache=shared` is silently dropped. So `writeDB` and `hookDB` get ordinary per-connection `SQLITE_BUSY` contention, not shared-cache semantics.
2. **Data races in `XsyncTransactionStore` / `MemoryMetaStore`** on the transaction commit path under `-race`. `MemoryMetaStore` is the production metastore, so this is not test-only.
3. **`StreamSnapshot`'s `req.Database != ""` branch is unreachable** — both production callers leave `Database` empty. It is dead code, and its cache-hit path would advertise a live schema version alongside stale cached files if anyone wired it up.
4. **A write-write conflict outranks a remote DDL rejection** in the same PREPARE round, so a mixed DML+DDL transaction can return a retry signal instead of the final rejection. Self-healing across retries.
5. **Secondary indexes cannot be created through the MySQL protocol** — standalone `CREATE INDEX` transpiles to `alter table t add key ...`, which SQLite rejects, and an inline non-unique `KEY` is silently dropped because only `Statements[0]` is consumed. The silent case is the worse one: the table is created, no error, no index.
6. **A lagging replica's `no such table` at PREPARE** is treated as a hard rejection rather than something retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
